### PR TITLE
873 DES add text

### DIFF
--- a/frontend/src/assets/content/deschutes/how-to-cut/measuring.md
+++ b/frontend/src/assets/content/deschutes/how-to-cut/measuring.md
@@ -9,3 +9,5 @@ to help you measure and choose a tree that meets your permit's restrictions.
 ![No cutting tops of trees off](/assets/img/site-wide/tree-top-icon.svg "no tree-topping")  **Take the whole tree.** Cutting the tree top off is prohibited.
 
 If snow is on the ground, remove it from around the stump so you can accurately measure the stump and tree height.
+
+Make sure that another tree is within 20 feet of the one you cut.


### PR DESCRIPTION
Adds text to the information page about making sure another tree is within 20 feet of the one being cut. This was missed in the initial tasks list for information page content build, but was captured in the Rules Story.

﻿## Summary
Addresses Issue #873  

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
- Information page, main landing page under measuring your tree section.

## Optional Screenshots
n/a

## This pull request changes...
- [ ] expected change 1

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
