### PR TITLE
940 OkaWen Rules Typo

### DIFF
--- a/frontend/src/assets/content/okawen/where-to-cut-your-tree/prohibited-areas.md
+++ b/frontend/src/assets/content/okawen/where-to-cut-your-tree/prohibited-areas.md
@@ -8,7 +8,7 @@ Cut trees only within the national forest boundary and respect surrounding priva
     * Naches District—along Highway 410, Highway 12, and Forest Service Roads #1200, #1800, and #1900
     * Entiat District—along the Entiat Valley Road
     * Cle Elum District—along I-90 and Highway 97
-    * Methow Valley District—along Highway 20 over Loup Loup Pass between Twisp and Okanogan-Wenatchee. Along Harts Pass road #5400. Along North Cascades Scenic Highway between east and west scenic highway portal signs (including all side roads).
+    * Methow Valley District—along Highway 20 over Loup Loup Pass between Twisp and Okanogan. Along Harts Pass road #5400. Along North Cascades Scenic Highway between east and west scenic highway portal signs (including all side roads).
 * 150 feet of any stream, lake, pond, or wetland area.
 * Active timber sales areas.
 * Privately owned or state-managed land within the National Forest boundary.


### PR DESCRIPTION
Under Methow Valley District, put a period after the word Okanogan (the "–Wenatchee" needs to be removed). so that it reads: "Methow Valley District–along Highway 20 over Loup Loup Pass between Twisp and Okanogan

﻿## Summary
Addresses Issue #940 summarized above

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
Prohibited Areas


## This pull request changes...
- [x] expected change 1

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
