### PR TITLE
940 Rules Typo

### DIFF
--- a/frontend/src/assets/content/okawen/tree-cutting-rules.md
+++ b/frontend/src/assets/content/okawen/tree-cutting-rules.md
@@ -12,7 +12,7 @@
 ### Do not cut trees within 200 feet of the following roads:
 * Highway 410, Highway 12, and Forest Service Roads 1200, 1800, and 1900 (Naches District),
 * the Entiat Valley Road (Entiat Ranger District),
-* Highway 20 over Loup Loup Pass between Twisp and Okanogan-Wenatchee (Methow Valley Ranger District), and
+* Highway 20 over Loup Loup Pass between Twisp and Okanogan (Methow Valley Ranger District), and
 * along Harts Pass road 5400 and the North Cascades Scenic Highway between the east and west scenic highway portaly signs, including all side roads (Methow Valley Ranger District).
 
 ### Do not cut trees within


### PR DESCRIPTION
Under the Methow Valley District section, there should be a period after the word Okanogan (the –Wenatchee needs to be removed). so that it reads: "Methow Valley District–along Highway 20 over Loup Loup Pass between Twisp and Okanogan.”

﻿## Summary
Addresses Issue #940   summarized above

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
Rules and Guidelines


## This pull request changes...
- [x] expected change 1

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
