### PR TITLE
843 dual permits

### DIFF
--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -60,6 +60,13 @@ const addForestSpecificInfo = (permit, frag) => {
   } else {
     frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FOREST';
   }
+  if (frag.querySelector('#forest-name_1_').textContent === 'DESCHUTES') {
+    frag.querySelector('#forest-name_1_').textContent = 'DESCHUTES AND OCHOCO';
+    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FORESTS';
+  } else if (frag.querySelector('#forest-name_1_').textContent === 'OCHOCO') {
+    frag.querySelector('#forest-name_1_').textContent = 'DESCHUTES AND OCHOCO';
+    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FORESTS';
+  }
   frag.querySelector('#permit-year-vertical_1_').textContent = permit.christmasTreesForest.startDate.getFullYear();
 
   frag.querySelector('#permit-expiration_1_').textContent = `${moment

--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -54,18 +54,17 @@ const addApplicantInfo = (permit, frag) => {
  * @param {Object} fragment - jsdom fragment
  */
 const addForestSpecificInfo = (permit, frag) => {
-  frag.querySelector('#forest-name_1_').textContent = permit.christmasTreesForest.forestNameShort.toUpperCase();
-  if (permit.christmasTreesForest.forestNameShort.indexOf(' and ') > 0) {
-    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FORESTS';
-  } else {
-    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FOREST';
+  const name = frag.querySelector('#forest-name_1_');
+  const nationalForest = frag.querySelector('#national-forest_1_');
+  name.textContent = permit.christmasTreesForest.forestNameShort.toUpperCase();
+  if (name.textContent === 'DESCHUTES' || name.textContent === 'OCHOCO') {
+    nationalForest.textContent = 'NATIONAL FORESTS';
+    name.textContent = 'DESCHUTES AND OCHOCO';
   }
-  if (frag.querySelector('#forest-name_1_').textContent === 'DESCHUTES') {
-    frag.querySelector('#forest-name_1_').textContent = 'DESCHUTES AND OCHOCO';
-    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FORESTS';
-  } else if (frag.querySelector('#forest-name_1_').textContent === 'OCHOCO') {
-    frag.querySelector('#forest-name_1_').textContent = 'DESCHUTES AND OCHOCO';
-    frag.querySelector('#national-forest_1_').textContent = 'NATIONAL FORESTS';
+  if (permit.christmasTreesForest.forestNameShort.indexOf(' and ') > 0) {
+    nationalForest.textContent = 'NATIONAL FORESTS';
+  } else {
+    nationalForest.textContent = 'NATIONAL FOREST';
   }
   frag.querySelector('#permit-year-vertical_1_').textContent = permit.christmasTreesForest.startDate.getFullYear();
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #843 

Please note if fully resolves the issue per the acceptance criteria: Yes

*displays DESCHUTES AND OCHOCO on printed permits printed for either forest. Code refactor.*

## Impacted Areas of the Site
Printed Permits

## This pull request changes...
- [ ] Deschutes x-mas tree permit displays DESCHUTES AND OCHOCO
- [ ] Ochoco x-mas tree permit displays DESCHUTES AND OCHOCO

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
