### PR TITLE
fix to say DESCHUTES AND OCHOCO NATIONAL FORESTS

### DIFF
--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -57,14 +57,14 @@ const addForestSpecificInfo = (permit, frag) => {
   const name = frag.querySelector('#forest-name_1_');
   const nationalForest = frag.querySelector('#national-forest_1_');
   name.textContent = permit.christmasTreesForest.forestNameShort.toUpperCase();
-  if (name.textContent === 'DESCHUTES' || name.textContent === 'OCHOCO') {
-    nationalForest.textContent = 'NATIONAL FORESTS';
-    name.textContent = 'DESCHUTES AND OCHOCO';
-  }
   if (permit.christmasTreesForest.forestNameShort.indexOf(' and ') > 0) {
     nationalForest.textContent = 'NATIONAL FORESTS';
   } else {
     nationalForest.textContent = 'NATIONAL FOREST';
+  }
+  if (name.textContent === 'DESCHUTES' || name.textContent === 'OCHOCO') {
+    nationalForest.textContent = 'NATIONAL FORESTS';
+    name.textContent = 'DESCHUTES AND OCHOCO';
   }
   frag.querySelector('#permit-year-vertical_1_').textContent = permit.christmasTreesForest.startDate.getFullYear();
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #843 

Please note if fully resolves the issue per the acceptance criteria: yes

* If deschutes or ochoco are now selected it readly in the plural form*



## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
