### PR TITLE
convert file pdf name to ChristmasTreePermit

### DIFF
--- a/frontend/src/app/application-forms/tree-application-form/tree-permit-view/tree-permit-view.component.ts
+++ b/frontend/src/app/application-forms/tree-application-form/tree-permit-view/tree-permit-view.component.ts
@@ -83,7 +83,7 @@ export class TreePermitViewComponent implements OnInit {
    * Create popup containing printable permit
    */
   printPermit() {
-    const popupWin = this.nativeWindow.open('', '_blank', 'top=0,left=0,height=auto,width=auto');
+    const popupWin = this.nativeWindow.open('ChristmasTreePermit', '_blank', 'top=0,left=0,height=auto,width=auto');
 
     const includeRules = this.includeRules;
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #631 

Please note if fully resolves the issue per the acceptance criteria: Yes

*Change pdf downloaded name to ChristmasTreePermit*

## Impacted Areas of the Site
- /christmas-trees/confirmation

## Optional Screenshots
<img width="1333" alt="Screen Shot 2019-10-30 at 1 13 29 PM" src="https://user-images.githubusercontent.com/18233188/67881704-5b887580-fb17-11e9-874f-d46112d1d2e9.png">

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
