### PR TITLE
1006 OkaWen Brochures

### DIFF
--- a/frontend/src/assets/content/okawen/contact-us.md
+++ b/frontend/src/assets/content/okawen/contact-us.md
@@ -1,6 +1,6 @@
 You can buy Christmas tree permits in person at the following Okanogan-Wenatchee National Forest ranger district offices or at [local vendors](https://www.fs.usda.gov/detail/okawen/passes-permits/forestproducts/?cid=fsbdev3_053596). Each district office has different hours during the Christmas tree cutting season. Call first to make sure someone is available to sell permits. All offices are closed on federal holidays.
 
-A PDF version of our Christmas Tree cutting information is available to view or print in either [English](/assets/files/okawen-english.pdf) or [Spanish](/assets/files/okawen-spanish.pdf).
+Downloadable versions of Christmas tree cutting information in English or Spanish are also available by [clicking here](https://www.fs.usda.gov/detail/okawen/passes-permits/?cid=fsbdev3_053596).
 
 ### Okanogan-Wenatchee National Forest Headquarters
 215 Melody Lane   


### PR DESCRIPTION
Removing the 2018 brochures, and linking to FS website for updated info

﻿## Summary
Addresses Issue #1006  

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*
This updated the text and hyper links under the contact us section for the Oka-Wen information brochures. Currently the site has links to Spanish and English brochures, however those are internal and would require Open Forest to update more things each year. The pilot POC preference is to link back to the FS website for the information. This pull request satisfies that for MVP.

## Impacted Areas of the Site
- Contact Us

## Optional Screenshots are available in the story.

## This pull request changes...
- [ ] expected change 1

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security 
- [x] This code has been reviewed by someone other than the original author
