### PR TITLE
1038 - updated replace() method to replace all instances

### DIFF
--- a/frontend/e2e/authenticated/christmas-trees/xmas-tree-application.e2e-spec.ts
+++ b/frontend/e2e/authenticated/christmas-trees/xmas-tree-application.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('Apply for a Christmas tree permit', () => {
 
     it('should display the permit name in the header', () => {
       christmasTreeForm.navigateTo(forestId);
-      expect<any>(element(by.css('app-root h1')).getText()).toEqual('Mt. Hood National Forest Christmas Tree permit information');
+      expect<any>(element(by.css('app-root h1')).getText()).toEqual('Buy a Christmas tree permit');
     });
 
     it('should show the breadcrumb', () => {

--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -253,14 +253,11 @@ christmasTreesPermitSvgUtil.parseCuttingAreaDates = (rulesText, forest) => {
     const areaKey = key.toUpperCase();
     const cuttingAreas = forest.cuttingAreas;
     if (cuttingAreas && cuttingAreas[areaKey] && cuttingAreas[areaKey].startDate) {
-      rulesTextWithDate = rulesText.replace(
-        `{{${key}Date}}`,
-        christmasTreesPermitSvgUtil.formatCuttingAreaDate(
-          forest.timezone,
-          cuttingAreas[areaKey].startDate,
-          cuttingAreas[areaKey].endDate
-        )
-      );
+      rulesTextWithDate = rulesText.replace(new RegExp(`{{${key}Date}}`, 'g'), christmasTreesPermitSvgUtil.formatCuttingAreaDate(
+        forest.timezone,
+        cuttingAreas[areaKey].startDate,
+        cuttingAreas[areaKey].endDate
+      ));
     }
   }
   return rulesTextWithDate;

--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -253,11 +253,13 @@ christmasTreesPermitSvgUtil.parseCuttingAreaDates = (rulesText, forest) => {
     const areaKey = key.toUpperCase();
     const cuttingAreas = forest.cuttingAreas;
     if (cuttingAreas && cuttingAreas[areaKey] && cuttingAreas[areaKey].startDate) {
-      rulesTextWithDate = rulesText.replace(new RegExp(`{{${key}Date}}`, 'g'), christmasTreesPermitSvgUtil.formatCuttingAreaDate(
-        forest.timezone,
-        cuttingAreas[areaKey].startDate,
-        cuttingAreas[areaKey].endDate
-      ));
+      rulesTextWithDate = rulesText.replace(new RegExp(`{{${key}Date}}`, 'g'),
+        christmasTreesPermitSvgUtil.formatCuttingAreaDate(
+          forest.timezone,
+          cuttingAreas[areaKey].startDate,
+          cuttingAreas[areaKey].endDate
+        )
+      );
     }
   }
   return rulesTextWithDate;

--- a/server/src/services/christmas-trees-permit-svg-util.es6
+++ b/server/src/services/christmas-trees-permit-svg-util.es6
@@ -258,8 +258,7 @@ christmasTreesPermitSvgUtil.parseCuttingAreaDates = (rulesText, forest) => {
           forest.timezone,
           cuttingAreas[areaKey].startDate,
           cuttingAreas[areaKey].endDate
-        )
-      );
+        ));
     }
   }
   return rulesTextWithDate;


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1038  

`replace()` method for cutting area dates only looked for one instance to replace. it now will replace all possible instances

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
