### PR TITLE
1071 MBSVendorsLink

### DIFF
--- a/frontend/src/assets/content/mbs/contact-us.md
+++ b/frontend/src/assets/content/mbs/contact-us.md
@@ -1,4 +1,4 @@
-You can buy Christmas tree permits in person at the following Mt. Baker-Snoqualmie National Forest ranger district offices, public service centers, or at [local vendors](https://www.fs.usda.gov/detail/mbs/news-events/?cid=STELPRDB5440163). Each district office has different hours during the Christmas tree cutting season. Call first to make sure someone is available to sell permits. All offices are closed on federal holidays.
+You can buy Christmas tree permits in person at the following Mt. Baker-Snoqualmie National Forest ranger district offices, public service centers, or at [local vendors](https://www.fs.usda.gov/detail/mbs/passes-permits/forestproducts/?cid=fseprd602862). Each district office has different hours during the Christmas tree cutting season. Call first to make sure someone is available to sell permits. All offices are closed on federal holidays.
 
 ### Mt. Baker Ranger Station
 810 State Route 20    


### PR DESCRIPTION
updating vendors link so that it does not take user to a news release, instead it takes them to MBS christmas tree page.

﻿## Summary
Addresses Issue #1071 

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
- Contact Us

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
