### PR TITLE
1040 - added dummy page for printing permits so no 404 page would show

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { ApplicationSubmittedComponent } from './application-forms/application-s
 import { AccessControlService } from './_services/access-control.service';
 import { AdminAccessControlService } from './_services/admin-access-control.service';
 import { ChristmasTreePermitResolver } from './application-forms/tree-application-form/christmas-tree-permit-resolver.service';
+import { DummyComponent } from './print-permit-dummy-page/dummy.component';
 import { ForestResolver } from './trees/forests/tree-guidelines/forest-resolver.service';
 import { ForestsResolver } from './trees/forests/forest-finder/forests-resolver.service';
 import { HelpMePickComponent } from './help-me-pick/help-me-pick.component';
@@ -42,8 +43,10 @@ const appRoutes: Routes = [
     path: '',
     redirectTo: 'christmas-trees/forests',
     pathMatch: 'full'
-  },
-  {
+  }, {
+    path: 'ChristmasTreePermit',
+    component: DummyComponent
+  }, {
     path: 'mbs',
     data: {
       title: 'US Forest Service Open Forest',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AuthenticationService } from './_services/authentication.service';
 import { Base64 } from './_pipes/base64.pipe';
 import { CancelApplicationComponent } from './applications/actions/cancel-application.component';
 import { DaysToOrDate } from './_pipes/days-to-or-date.pipe';
+import { DummyComponent } from './print-permit-dummy-page/dummy.component';
 import { ErrorInterceptor } from './error-pages/error-interceptor.service';
 import { HelpMePickComponent } from './help-me-pick/help-me-pick.component';
 import { HoursFromOrDate } from './_pipes/hours-from-or-date.pipe';
@@ -53,6 +54,7 @@ import { GoogleAnalyticsService } from './_services/google-analytics.service';
     Base64,
     CancelApplicationComponent,
     DaysToOrDate,
+    DummyComponent,
     ForestAdminNavComponent,
     HelpMePickComponent,
     HomeComponent,

--- a/frontend/src/app/print-permit-dummy-page/dummy.component.html
+++ b/frontend/src/app/print-permit-dummy-page/dummy.component.html
@@ -1,0 +1,3 @@
+<section id="home" class="usa-section">
+
+</section>

--- a/frontend/src/app/print-permit-dummy-page/dummy.component.ts
+++ b/frontend/src/app/print-permit-dummy-page/dummy.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dummy',
+  templateUrl: './dummy.component.html'
+})
+export class DummyComponent {
+  constructor(
+  ) {
+  }
+}


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1040 

Please note if fully resolves the issue per the acceptance criteria: Y

When printing a permit, a 404 page will no longer briefly flash.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
