### PR TITLE
566 required fields

### DIFF
--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -103,7 +103,7 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
       {validator: emailConfirmationValidator('emailAddress', 'emailAddressConfirmation')}),
       guideIdentification: ['', [Validators.maxLength(255)]],
       operatingPlan: ['', [Validators.maxLength(255)]],
-      liabilityInsurance: ['', [Validators.maxLength(255)]],
+      liabilityInsurance: ['', [Validators.required, Validators.maxLength(255)]],
       acknowledgementOfRisk: ['', [Validators.maxLength(255)]],
       locationMap: ['', [Validators.maxLength(255)]],
       tempOutfitterFields: this.formBuilder.group({

--- a/frontend/src/sass/elements/_input.scss
+++ b/frontend/src/sass/elements/_input.scss
@@ -162,4 +162,6 @@ input[disabled] {
 
 .required-fields-asterisk {
   color: $fs-red;
+  font-size: 17px;
+  font-weight: bold;
 }


### PR DESCRIPTION
﻿## Summary
Addresses Issue #566 

## Optional Screenshots
![image](https://user-images.githubusercontent.com/5187168/69998312-0085dc00-1524-11ea-9f47-dd3e46444d13.png)

![image](https://user-images.githubusercontent.com/5187168/69998337-198e8d00-1524-11ea-96ba-77ad21e9a8ae.png)

## This pull request changes...
The size of the required field asterisks by making them all the same.
The validation for Liability Insurance on temporary outfitter applications is now required, and the corresponding icon is now displayed.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
