### PR TITLE
566 - enforce font family for required fields asterisk

### DIFF
--- a/frontend/src/sass/elements/_input.scss
+++ b/frontend/src/sass/elements/_input.scss
@@ -164,4 +164,5 @@ input[disabled] {
   color: $fs-red;
   font-size: 17px;
   font-weight: bold;
+  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
 }


### PR DESCRIPTION
﻿## Summary
Addresses Issue #566 

This enforces the `font-family` for the required asterisk.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
