### PR TITLE
1105 - cancel button is no longer displayed for admins on the applica…

### DIFF
--- a/frontend/src/app/applications/permit-application-view/permit-application-view.component.html
+++ b/frontend/src/app/applications/permit-application-view/permit-application-view.component.html
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div class="usa-grid cancel-application-wrapper">
-    <app-cancel-application (applicationCancelled)="applicationCancelled($event)" [application]="application" text="Cancel application."></app-cancel-application>
+    <app-cancel-application *ngIf="!isAdmin" (applicationCancelled)="applicationCancelled($event)" [application]="application" text="Cancel application."></app-cancel-application>
   </div>
   <div class="sticky-bar bottom app-ctas" [class.fixed]="fixedCtas" *ngIf="isAdmin && (application.status === 'Hold' || ['Submitted', 'Review'].indexOf(application.status) !== -1)">
     <div id="cta-buttons" *ngIf="!reasonOrCancel.open">


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1105 

This PR removes the cancel button for admins from the applications detail view.

![image](https://user-images.githubusercontent.com/5187168/71230478-cb191680-22b7-11ea-9373-329040cc40ef.png)

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
