### PR TITLE
initial rolling timeout and session destroy

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -58,11 +58,14 @@ app.use(
   session({
     name: 'session',
     keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
+    saveUninitialized: false,
+    resave: true,
+    rolling: true,
     cookie: {
       secure: true,
       httpOnly: true,
       domain,
-      expires: new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+      maxAge: 20 * 60 * 1000 // 1 hour
     }
   })
 );

--- a/server/src/auth/passport-config.es6
+++ b/server/src/auth/passport-config.es6
@@ -91,10 +91,9 @@ passportConfig.logout = (req, res) => {
   }
 
   const { user } = req;
-
   if (user) {
     req.logout();
-
+    req.session = null;
     // login.gov requires the user to visit the idp to logout
     if (user.role === 'user' && !MOCK_PUBLIC_AUTH) {
       logger.info(`AUTHENTICATION: ${user.email} logging out via Login.gov.`);


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1113 and #762 

Please note if fully resolves the issue per the acceptance criteria: Yes

PR to add a rolling session variable with a 20 minute inactivity timeout. Also add req.session = null for cookie-session session package upon logout

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
