### PR TITLE
set 1 hour timeout with sessions complete

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -58,17 +58,24 @@ app.use(
   session({
     name: 'session',
     keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
-    saveUninitialized: false,
-    resave: true,
-    rolling: true,
+    maxAge: 3600000, // 1 hour
     cookie: {
       secure: true,
       httpOnly: true,
-      domain,
-      maxAge: 20 * 60 * 1000 // 1 hour
+      domain
     }
   })
 );
+
+// eslint-disable-next-line prefer-arrow-callback
+app.get('*', function refresh(req, res, next) {
+  // To update the session expiration time we need to send the new
+  // expiration in the response cookie.
+  // To send again the response cookie to the client we need to
+  // update the session object.
+  req.session.fake = Date.now();
+  next();
+});
 
 /** set meridiem format to AM and PM */
 moment.updateLocale('en', {


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1135 

Please note if fully resolves the issue per the acceptance criteria: Yes

Ended up not having to install express-session and was able to keep cookie-sessions in place. Timeout needed to be manually set pushing new data to the session to keep the user session active while also keeping a maxage set.

Side Note: cookie-session maxAge cannot accept mathematic functions and needs to be set manually and not in the cookie object.


## This pull request changes...
- [x] User is now timed out after an hour of inactivity
- [x] Upon timing out, a users session is destroyed
- [x] A user can keep using the application as long as they wish as long as they are pushing / posting data, or navigating pages.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] Server actions captured by logs (manual)
- [x] This code has been reviewed by someone other than the original author
