### PR TITLE
406 - nothing sets the status to expired, so we search for submitted …

### DIFF
--- a/server/src/controllers/common.es6
+++ b/server/src/controllers/common.es6
@@ -62,6 +62,24 @@ const findOrCondition = (req) => {
       orCondition = [
         {
           status: 'Expired'
+        },
+        {
+          status: 'Submitted'
+        },
+        {
+          status: 'Hold'
+        },
+        {
+          status: 'Rejected'
+        },
+        {
+          status: 'Cancelled'
+        },
+        {
+          status: 'Accepted'
+        },
+        {
+          status: 'Review'
         }
       ];
       break;
@@ -88,6 +106,10 @@ commonControllers.getPermitApplications = (req, res) => {
       authEmail: req.user.email
     });
   }
+  let expiredCondition = Sequelize.Op.gt;
+  if (req.params.statusGroup === 'expired') {
+    expiredCondition = Sequelize.Op.lt;
+  }
   const noncommercialApplicationsPromise = NoncommercialApplication.findAll({
     attributes: [
       'appControlNumber',
@@ -105,7 +127,7 @@ commonControllers.getPermitApplications = (req, res) => {
       [Sequelize.Op.or]: orCondition,
       [Sequelize.Op.and]: andCondition,
       noncommercialFieldsEndDateTime: {
-        [Sequelize.Op.gt]: new Date()
+        [expiredCondition]: new Date()
       }
     },
     order: [['createdAt', 'DESC']]
@@ -127,7 +149,7 @@ commonControllers.getPermitApplications = (req, res) => {
       [Sequelize.Op.or]: orCondition,
       [Sequelize.Op.and]: andCondition,
       tempOutfitterFieldsActDescFieldsEndDateTime: {
-        [Sequelize.Op.gt]: new Date()
+        [expiredCondition]: new Date()
       }
     },
     order: [['createdAt', 'DESC']]


### PR DESCRIPTION
﻿## Summary
Addresses Issue #406 

Please note if fully resolves the issue per the acceptance criteria: Y

Admins can now view "expired" applications

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
