### PR TITLE
#207 Update nodejs from 8.15.1 to 10.18.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -100,7 +100,7 @@
     "prepare": "npm run snyk-protect"
   },
   "engines": {
-    "node": "^8.15.1"
+    "node": "^10.18.0"
   },
   "nyc": {
     "extension": [


### PR DESCRIPTION
*Describe the pull request here, including any supplemental information needed to understand it.*
Tested in dev and pushing in staging. The buildback nodejs in cloudfoundry removed the version of 8.15.1 recently. Upgrading to 10.18.1

https://github.com/cloudfoundry/nodejs-buildpack/issues/216 

## Impacted Areas of the Site
- none

## This pull request changes...
- [x] nodejs in package.json

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
