### PR TITLE
980 - no longer adding additional day to season dates after a change …

### DIFF
--- a/server/src/controllers/christmas-tree/admin.es6
+++ b/server/src/controllers/christmas-tree/admin.es6
@@ -199,7 +199,7 @@ christmasTreeAdmin.updateForestDetails = (req, res) => {
             startDate = moment.tz(req.body.startDate, forest.timezone).format(util.datetimeFormat);
             endDate = moment
               .tz(req.body.endDate, forest.timezone)
-              .add(1, 'days')
+              .add(0, 'days')
               .subtract(1, 'ms')
               .format(util.datetimeFormat);
           }


### PR DESCRIPTION
 This PR fixes an issue that would cause the end date for seasons to increment by 1 after being saved.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
