### PR TITLE
1163 - FirstLast-Character-Limits

### DIFF
--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -96,8 +96,8 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
             '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$'
           ), Validators.maxLength(255)]],
         organizationName: ['', [alphanumericValidator(), Validators.maxLength(60)]],
-        primaryFirstName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
-        primaryLastName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
+        primaryFirstName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(36)]],
+        primaryLastName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(60)]],
         orgType: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
         website: ['', [urlValidator(), Validators.maxLength(255)]],
         goodStandingEvidence: ['', [Validators.maxLength(255)]]


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1163

This PR sets first and last name character limits along with validation messaging and border-color change to indicate whether or not a user's first or last name violates the set character limits for the Christmas tree application page, the non-commercial group application page, and the temporary outfitters application page.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
