### PR TITLE
Snyk fix in dev

### DIFF
--- a/server/.snyk
+++ b/server/.snyk
@@ -46,13 +46,13 @@ ignore:
   SNYK-JS-LODASH-450202:
     - snyk > snyk-nodejs-lockfile-parser > lodash:
         reason: No upgrade path available
-        expires: '2020-02-08T16:11:43.777Z'
+        expires: '2020-05-08T16:11:43.777Z'
     - openid-client > node-jose > lodash:
         reason: not actually patching
-        expires: '2020-02-08T04:16:00.748Z'
+        expires: '2020-05-08T04:16:00.748Z'
     - openid-client > node-jose > lodash:
         reason: not actually patching
-        expires: '2020-02-08T14:58:22.562Z'
+        expires: '2020-05-08T14:58:22.562Z'
     - snyk > snyk-nuget-plugin > dotnet-deps-parser > lodash:
         reason: None given
         expires: '2019-09-19T14:59:24.052Z'
@@ -70,49 +70,49 @@ ignore:
         expires: '2020-02-21T16:18:33.936Z'
     - snyk > @snyk/snyk-cocoapods-plugin > @snyk/dep-graph > lodash:
         reason: None given
-        expires: '2020-02-21T16:22:41.008Z'
+        expires: '2020-05-21T16:22:41.008Z'
     - snyk > @snyk/snyk-cocoapods-plugin > @snyk/cocoapods-lockfile-parser > @snyk/dep-graph > lodash:
         reason: None given
-        expires: '2020-02-21T16:22:41.008Z'
+        expires: '2020-05-21T16:22:41.008Z'
     - snyk > @snyk/snyk-cocoapods-plugin > @snyk/dep-graph > graphlib > lodash:
         reason: None given
-        expires: '2020-02-21T16:22:41.008Z'
+        expires: '2020-05-21T16:22:41.008Z'
     - snyk > @snyk/snyk-cocoapods-plugin > @snyk/cocoapods-lockfile-parser > @snyk/dep-graph > graphlib > lodash:
         reason: None given
-        expires: '2020-02-21T16:22:41.008Z'
+        expires: '2020-05-21T16:22:41.008Z'
     - express-winston > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - html-to-text > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - jsdom > request-promise-native > request-promise-core > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - newrelic > async > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - openid-client > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - passport-saml > xml-encryption > async > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - request-promise-native > request-promise-core > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - sequelize > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - snyk > @snyk/dep-graph > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - winston > async > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
     - xml-encryption > async > lodash:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-05-20T21:18:10.419Z'
   SNYK-JS-LODASHMERGEWITH-174136:
     - ink-docstrap > sanitize-html > lodash.mergewith:
         reason: No upgrade path available
@@ -136,15 +136,15 @@ ignore:
   SNYK-JS-MARKDOWNIT-459438:
     - jsdoc > markdown-it:
         reason: None given
-        expires: '2020-02-08T18:09:41.408Z'
+        expires: '2020-05-08T18:09:41.408Z'
   SNYK-JS-TREEKILL-536781:
     - snyk > snyk-sbt-plugin > tree-kill:
         reason: no upgrade path currenty
-        expires: '2020-03-08T15:38:05.011Z'
+        expires: '2020-05-08T15:38:05.011Z'
   SNYK-JS-HTTPSPROXYAGENT-469131:
     - newrelic > https-proxy-agent:
         reason: None given
-        expires: '2020-02-20T21:18:10.419Z'
+        expires: '2020-06-20T21:18:10.419Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:


### PR DESCRIPTION
Snyk vulnerability fix in dev.
Issues with no direct upgrade or patch:
  ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-JS-MARKDOWNIT-459438] in markdown-it@8.4.2
    introduced by jsdoc@3.6.3 > markdown-it@8.4.2
  This issue was fixed in versions: 10.0.0

## This pull request is ready to merge when...
-
- [ ] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
