### PR TITLE
add 1 hour to compensate for moment timezones

### DIFF
--- a/server/src/controllers/christmas-tree/admin.es6
+++ b/server/src/controllers/christmas-tree/admin.es6
@@ -196,11 +196,13 @@ christmasTreeAdmin.updateForestDetails = (req, res) => {
             cuttingAreas = req.body.cuttingAreas;
           }
           if (req.body.startDate && req.body.endDate) {
-            startDate = moment.tz(req.body.startDate, forest.timezone).format(util.datetimeFormat);
+            startDate = moment
+              .tz(req.body.startDate, forest.timezone)
+              .add(1, 'hours')
+              .format(util.datetimeFormat);
             endDate = moment
               .tz(req.body.endDate, forest.timezone)
-              .add(0, 'days')
-              .subtract(1, 'ms')
+              .add(1, 'hours')
               .format(util.datetimeFormat);
           }
           return forest

--- a/server/src/services/forest.service.es6
+++ b/server/src/services/forest.service.es6
@@ -12,8 +12,8 @@ const forestService = {};
  * @return {Object} - formatted data object
  */
 forestService.translateForestFromDatabaseToClient = (input) => {
-  const startDate = moment(input.startDate);
-  const endDate = moment(input.endDate);
+  const startDate = moment(input.startDate).local();
+  const endDate = moment(input.endDate).local();
 
   return {
     id: input.id,
@@ -27,8 +27,8 @@ forestService.translateForestFromDatabaseToClient = (input) => {
     treeHeight: input.treeHeight,
     stumpHeight: input.stumpHeight,
     stumpDiameter: input.stumpDiameter,
-    startDate: startDate.tz(input.timezone).format('YYYY-MM-DD HH:mm:ss'),
-    endDate: endDate.tz(input.timezone).format('YYYY-MM-DD HH:mm:ss'),
+    startDate: startDate.format('YYYY-MM-DD HH:mm:ss'),
+    endDate: endDate.format('YYYY-MM-DD HH:mm:ss'),
     treeCost: input.treeCost,
     maxNumTrees: input.maxNumTrees,
     allowAdditionalHeight: input.allowAdditionalHeight,


### PR DESCRIPTION
﻿## Summary
Addresses Issue #980 

Please note if fully resolves the issue per the acceptance criteria: Yes

*moment is not correcting users pacific time correctly on add season dates, this should fix it*

## Impacted Areas of the Site
- /christmas-trees/forests/{forest}#season-dates
-/admin/christmas-trees/season-dates

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
