### PR TITLE
1194 onhold fax email

### DIFF
--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -36,13 +36,18 @@ export class FaxComponent implements OnInit {
           .get('fax.tenDigit')
           .setValidators([Validators.minLength(10), Validators.maxLength(10), Validators.required]);
         this.parentForm.get('fax.tenDigit').updateValueAndValidity();
+
       } else {
         this.parentForm.get('fax.tenDigit').setValidators([Validators.minLength(10), Validators.maxLength(10)]);
         this.parentForm.get('fax.tenDigit').updateValueAndValidity();
       }
     });
-
     this.afs.phoneChangeSubscribers(this.parentForm, 'fax');
+    this.parentForm.get('fax.tenDigit').valueChanges.subscribe(value => {
+      if (value === 0) {
+        this.parentForm.patchValue({fax: { tenDigit: null }})
+      }
+    })
   }
 
   ngOnInit() {
@@ -50,5 +55,3 @@ export class FaxComponent implements OnInit {
     this.changeSubscribers();
   }
 }
-
-

--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -45,9 +45,9 @@ export class FaxComponent implements OnInit {
     this.afs.phoneChangeSubscribers(this.parentForm, 'fax');
     this.parentForm.get('fax.tenDigit').valueChanges.subscribe(value => {
       if (value === 0) {
-        this.parentForm.patchValue({fax: { tenDigit: null }})
+        this.parentForm.patchValue({fax: { tenDigit: null }});
       }
-    })
+    });
   }
 
   ngOnInit() {

--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -36,7 +36,6 @@ export class FaxComponent implements OnInit {
           .get('fax.tenDigit')
           .setValidators([Validators.minLength(10), Validators.maxLength(10), Validators.required]);
         this.parentForm.get('fax.tenDigit').updateValueAndValidity();
-
       } else {
         this.parentForm.get('fax.tenDigit').setValidators([Validators.minLength(10), Validators.maxLength(10)]);
         this.parentForm.get('fax.tenDigit').updateValueAndValidity();

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -279,7 +279,7 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
         this.applicationId = application.applicationId;
         this.applicationForm.patchValue(this.application);
         this.getFiles(this.application.applicationId);
-        this.applicationForm.patchValue({ applicantInfo: { emailAddressConfirmation: application.applicantInfo.emailAddress }})
+        this.applicationForm.patchValue({ applicantInfo: { emailAddressConfirmation: application.applicantInfo.emailAddress }});
       },
       (e: any) => {
         this.apiErrors = e;

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -279,6 +279,7 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
         this.applicationId = application.applicationId;
         this.applicationForm.patchValue(this.application);
         this.getFiles(this.application.applicationId);
+        this.applicationForm.patchValue({ applicantInfo: { emailAddressConfirmation: application.applicantInfo.emailAddress }})
       },
       (e: any) => {
         this.apiErrors = e;


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1194 

Please note if fully resolves the issue per the acceptance criteria: Y

This changes the email confirmation to be prefilled when editing a SU application, and makes sure the fax doesn't have a "0" value.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
