### PR TITLE
convert map to allow doc, pdf, docx, rtf, remove png and jpg

### DIFF
--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.html
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.html
@@ -79,13 +79,12 @@
 
           <label id="location-map-label" class="usa-input">Map of proposed activity</label>
           <p id="location-map-hint-text" class="help-text usa-form-hint">In addition to the description provided above, you may also include a map for further clarification of the specific areas you will be using within the forest.</p>
-          <p class="help-text usa-form-hint">File must be in .jpg, .png, or .pdf format, and less than 10MB.</p>
+          <p class="help-text usa-form-hint">File must be in .pdf, .doc, .docx., or .rtf format, and less than 10MB.</p>
           <app-file-upload-field name="Location map" type="location-map"
             [uploadFiles]="uploadFiles"
             [applicationId]="applicationId"
             [checkFileUploadHasError]="submitted"
             [field]="applicationForm.controls.locationMap"
-            allowImg="true"
             ></app-file-upload-field>
         </fieldset>
 

--- a/server/src/controllers/special-use/temp-outfitter.es6
+++ b/server/src/controllers/special-use/temp-outfitter.es6
@@ -462,6 +462,7 @@ const acceptApplication = application => new Promise((resolve, reject) => {
               !file.mimetype.includes('pdf')
               && !file.mimetype.includes('png')
               && !file.mimetype.includes('jpg')
+              && !file.mimetype.includes('jpeg')
               && !file.mimetype.includes('doc')
               && !file.mimetype.includes('docx')
               && !file.mimetype.includes('rtf')


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1193 

Please note if fully resolves the issue per the acceptance criteria: Yes

*Changes allowed upload types of map activities to doc, docx, pdf, and .rtf.*

## Impacted Areas of the Site
- /mbs/temp-outfitters/applications

## This pull request changes...
- [x] will only allow supported map types 
- [x] will correctly display uploaded maps in user/applications

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
