### PR TITLE
1165 incompatible browser warning

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,6 +2,12 @@
 <a tabindex="0" class="usa-skipnav" href="#skip-nav-target" (click)="util.gotoHashtag('skip-nav-target', $event)">Skip to main content</a>
 <header id="header" role="banner" class="usa-header usa-header-extended">
   <app-usa-banner></app-usa-banner>
+  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName()=='Chrome'">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">Warning</h3>
+      <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience, please switch to Google Chrome.</p>
+    </div>
+  </div>
   <div class="usa-navbar">
     <app-page-header></app-page-header>
   </div>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,7 +2,7 @@
 <a tabindex="0" class="usa-skipnav" href="#skip-nav-target" (click)="util.gotoHashtag('skip-nav-target', $event)">Skip to main content</a>
 <header id="header" role="banner" class="usa-header usa-header-extended">
   <app-usa-banner></app-usa-banner>
-  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName()=='Chrome'">
+  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="browserName != 'Chrome'">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Warning</h3>
       <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience, please switch to Google Chrome.</p>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,7 +2,7 @@
 <a tabindex="0" class="usa-skipnav" href="#skip-nav-target" (click)="util.gotoHashtag('skip-nav-target', $event)">Skip to main content</a>
 <header id="header" role="banner" class="usa-header usa-header-extended">
   <app-usa-banner></app-usa-banner>
-  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="browserName != 'Chrome'">
+  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName() !== 'Chrome'">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Warning</h3>
       <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience, please switch to Google Chrome.</p>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -56,23 +56,23 @@ export class AppComponent implements OnInit {
   getBrowserName() {
     const  userAgent = navigator.userAgent;
     let browserInfo = userAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
-    let parseBrowserInfo;
-    
+    let parsedBrowserInfo;
+
         if (/trident/i.test(browserInfo[1])) {
 
-          parseBrowserInfo = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
+          parsedBrowserInfo = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
 
-          return { name: 'IE', version: (parseBrowserInfo[1] || '') };
+          return { name: 'IE', version: (parsedBrowserInfo[1] || '') };
 
         }
 
     if (browserInfo[1] === 'Chrome') {
 
-        parseBrowserInfo = userAgent.match (/\bOPR|Edge\/(\d+)/);
+        parsedBrowserInfo = userAgent.match (/\bOPR|Edge\/(\d+)/);
 
-        if (parseBrowserInfo != null)   {
+        if (parsedBrowserInfo != null)   {
 
-            return { name: 'Opera', version: parseBrowserInfo[1] };
+            return { name: 'Opera', version: parsedBrowserInfo[1] };
 
           }
 
@@ -80,9 +80,9 @@ export class AppComponent implements OnInit {
 
       browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
 
-    if (( parseBrowserInfo = userAgent.match(/version\/(\d+)/i)) != null) {
+    if (( parsedBrowserInfo = userAgent.match(/version\/(\d+)/i)) != null) {
 
-      browserInfo.splice(1, 1, parseBrowserInfo[1]);
+      browserInfo.splice(1, 1, parsedBrowserInfo[1]);
 
     }
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -17,6 +17,8 @@ export class AppComponent implements OnInit {
   apiurl = environment.apiUrl;
   currentUrl = '/';
   user: any;
+  browserName: string;
+  warningMessage: string;
   status = {
     heading: '',
     message: ''
@@ -26,6 +28,7 @@ export class AppComponent implements OnInit {
     public authentication: AuthenticationService,
     public util: UtilService,
     private meta: Meta) {
+    this.warningMessage = '',
     this.meta.addTag(
       { name: 'keywords',
        content: 'Forest Service, permitting, permits, christmas trees, national forest, national forests'
@@ -40,7 +43,6 @@ export class AppComponent implements OnInit {
         } else {
           window.scrollTo(0, 0);
         }
-
         if (this.authentication.user && localStorage.getItem('showLoggedIn')) {
           this.setLoggedInMessage(this.authentication.user);
         } else {
@@ -50,6 +52,35 @@ export class AppComponent implements OnInit {
       }
     });
   }
+
+  getBrowserName() {
+    const  usrAgent = navigator.userAgent;
+    let tem;
+    let browserInfo = usrAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+        if (/trident/i.test(browserInfo[1])) {
+
+        tem = /\brv[ :]+(\d+)/g.exec(usrAgent) || [];
+
+        return { name: 'IE', version: (tem[1] || '') };
+
+        }
+
+    if (browserInfo[1] === 'Chrome') {
+
+        tem = usrAgent.match (/\bOPR|Edge\/(\d+)/);
+
+        if (tem != null)   { return { name: 'Opera', version: tem[1] }; }
+
+        }
+
+      browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
+
+    if (( tem = usrAgent.match(/version\/(\d+)/i)) != null) { browserInfo.splice(1, 1, tem[1]); }
+
+    this.browserName = browserInfo[0];
+
+    return this.browserName;
+ }
 
   /**
    *  Set status message
@@ -90,5 +121,25 @@ export class AppComponent implements OnInit {
         return hour < 12 ? 'AM' : 'PM';
       }
     });
-  }
+   }
+  //   function throwWrnMsg() {
+
+  //     var browser = get_browser();
+
+  //     if(browser.name !== "Chrome") {
+
+  //      this.warningMessage = "Your browser is crap. Sorry for the inconvenience."
+
+  //     }
+
+  //     else{
+
+  //         console.log("Chrome in Use, Version: " + browser.version);
+
+  //     }
+
+  // }
+
+
+  // }
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -55,23 +55,24 @@ export class AppComponent implements OnInit {
 
   getBrowserName() {
     const  userAgent = navigator.userAgent;
-    let tem;
     let browserInfo = userAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+    let parseBrowserInfo;
+    
         if (/trident/i.test(browserInfo[1])) {
 
-          tem = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
+          parseBrowserInfo = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
 
-          return { name: 'IE', version: (tem[1] || '') };
+          return { name: 'IE', version: (parseBrowserInfo[1] || '') };
 
         }
 
     if (browserInfo[1] === 'Chrome') {
 
-        tem = userAgent.match (/\bOPR|Edge\/(\d+)/);
+        parseBrowserInfo = userAgent.match (/\bOPR|Edge\/(\d+)/);
 
-        if (tem != null)   {
+        if (parseBrowserInfo != null)   {
 
-            return { name: 'Opera', version: tem[1] };
+            return { name: 'Opera', version: parseBrowserInfo[1] };
 
           }
 
@@ -79,9 +80,9 @@ export class AppComponent implements OnInit {
 
       browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
 
-    if (( tem = userAgent.match(/version\/(\d+)/i)) != null) {
+    if (( parseBrowserInfo = userAgent.match(/version\/(\d+)/i)) != null) {
 
-      browserInfo.splice(1, 1, tem[1]);
+      browserInfo.splice(1, 1, parseBrowserInfo[1]);
 
     }
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -54,32 +54,41 @@ export class AppComponent implements OnInit {
   }
 
   getBrowserName() {
-    const  usrAgent = navigator.userAgent;
+    const  userAgent = navigator.userAgent;
     let tem;
-    let browserInfo = usrAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+    let browserInfo = userAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
         if (/trident/i.test(browserInfo[1])) {
 
-        tem = /\brv[ :]+(\d+)/g.exec(usrAgent) || [];
+          tem = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
 
-        return { name: 'IE', version: (tem[1] || '') };
+          return { name: 'IE', version: (tem[1] || '') };
 
         }
 
     if (browserInfo[1] === 'Chrome') {
 
-        tem = usrAgent.match (/\bOPR|Edge\/(\d+)/);
+        tem = userAgent.match (/\bOPR|Edge\/(\d+)/);
 
-        if (tem != null)   { return { name: 'Opera', version: tem[1] }; }
+        if (tem != null)   {
+
+            return { name: 'Opera', version: tem[1] };
+
+          }
 
         }
 
       browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
 
-    if (( tem = usrAgent.match(/version\/(\d+)/i)) != null) { browserInfo.splice(1, 1, tem[1]); }
+    if (( tem = userAgent.match(/version\/(\d+)/i)) != null) {
 
-    this.browserName = browserInfo[0];
+      browserInfo.splice(1, 1, tem[1]);
 
-    return this.browserName;
+    }
+
+     this.browserName = browserInfo[0];
+
+     return this.browserName;
+
  }
 
   /**
@@ -122,24 +131,4 @@ export class AppComponent implements OnInit {
       }
     });
    }
-  //   function throwWrnMsg() {
-
-  //     var browser = get_browser();
-
-  //     if(browser.name !== "Chrome") {
-
-  //      this.warningMessage = "Your browser is crap. Sorry for the inconvenience."
-
-  //     }
-
-  //     else{
-
-  //         console.log("Chrome in Use, Version: " + browser.version);
-
-  //     }
-
-  // }
-
-
-  // }
 }

--- a/frontend/src/sass/elements/_alerts.scss
+++ b/frontend/src/sass/elements/_alerts.scss
@@ -12,3 +12,17 @@
 .usa-alert a.usa-button:hover {
   color: white;
 }
+
+.application-browser-alert {
+  margin-top: 0rem;
+  max-width: 115rem;
+  @media (min-width: $large-screen) {
+    margin-left: 20%;
+    margin-right: 20%;
+  }
+  @media (min-width: $large-screen) {
+    margin-left: 25%;
+    margin-right: 25%;
+  }
+
+}

--- a/frontend/src/sass/elements/_alerts.scss
+++ b/frontend/src/sass/elements/_alerts.scss
@@ -17,12 +17,7 @@
   margin-top: 0rem;
   max-width: 115rem;
   @media (min-width: $large-screen) {
-    margin-left: 20%;
-    margin-right: 20%;
+    margin-left: 32rem;
+    margin-right: 32rem;
   }
-  @media (min-width: $large-screen) {
-    margin-left: 25%;
-    margin-right: 25%;
-  }
-
 }


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1165    

This code update completes the 1165 card by updating the app.component html and ts files along with the _alert.scss file in order to determine what browser a user is accessing Open Forest through and display a warning banner if they're using anything but Chrome.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author