### PR TITLE
1209 tog and ncgu character limits

### DIFF
--- a/frontend/src/app/application-forms/fields/activity-description.component.html
+++ b/frontend/src/app/application-forms/fields/activity-description.component.html
@@ -10,7 +10,7 @@
     <app-error-message fieldId="number-of-trips-error" name="Number of trips" [control]="parentForm.get('activityDescriptionFields.numberOfTrips')"></app-error-message>
 
     <label id="party-size-label" class="usa-input">The anticipated party size. <span class="required-fields-asterisk">*</span></label>
-    <p id="party-size-hint-text" class="help-text usa-form-hint">If you are planning multiple trips or are unsure of the exact number of attendees, please provide a range that covers the smallest party size to largest party size. For example, for an operation that could have as little as 5 attendees but as many as 25 attendees, you could enter 5-25.</p>
+    <p id="party-size-hint-text" class="help-text usa-form-hint">If you are planning multiple trips or are unsure of the exact number of attendees, please provide a range that covers the smallest party size to largest party size. For example, for an operation that could have as little as 5 attendees but as many as 25 attendees, you could enter 5-25 (1000 character limit).</p>
     <input id="party-size"  type="text" formControlName="partySize" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.partySize'), 'party-size-label party-size-hint-text', 'party-size-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.partySize'))"
@@ -18,13 +18,16 @@
     <app-error-message fieldId="party-size-error" name="Party size" [control]="parentForm.get('activityDescriptionFields.partySize')"></app-error-message>
 
     <label id="services-provided-label" class="usa-input">Services being offered. <span class="required-fields-asterisk">*</span></label>
-    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide a brief overview of the services you will be providing your attendees. Please make note of any services that will be provided by a party other than the permit holder.</p>
+    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide a brief overview of the services you will be providing your attendees. Please make note of any services that will be provided by a party other than the permit holder (1000 character limit).</p>
     <textarea id="services-provided"  type="text" formControlName="servicesProvided" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.servicesProvided'), 'services-provided-label services-provided-hint-text', 'services-provided-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.servicesProvided'))"></textarea>
     <app-error-message fieldId="services-provided-error" name="A list of services provided" [control]="parentForm.get('activityDescriptionFields.servicesProvided')"></app-error-message>
 
-    <label id="audience-description-label" class="usa-input" for="audience-description">Description of your client base or audience. <span class="required-fields-asterisk">*</span></label>
+    <label id="audience-description-label" class="usa-input" for="audience-description">Description of your client base or audience.
+      <span class="required-fields-asterisk">*</span>
+      <span class="help-text usa-form-hint character-limit-hint">(1000 character limit)</span>
+    </label>
     <textarea id="audience-description" type="text" formControlName="audienceDescription" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.audienceDescription'), 'audience-description-label', 'audience-description-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.audienceDescription'))"></textarea>
@@ -80,14 +83,17 @@
       <app-error-message fieldId="statement-of-assigned-site-error" name="A description of assigned site" [control]="parentForm.get('activityDescriptionFields.statementOfAssignedSite')"></app-error-message>
     </ng-container>
 
-    <label id="description-of-cleanup-and-restoration-label" class="usa-input">Description of cleanup and restoration during and after the proposed operations. <span class="required-fields-asterisk">*</span></label>
+    <label id="description-of-cleanup-and-restoration-label" class="usa-input">Description of cleanup and restoration during and after the proposed operations. 
+      <span class="required-fields-asterisk">*</span>
+      <span class="help-text usa-form-hint character-limit-hint">(1000 character limit)</span>
+    </label>
     <textarea id="description-of-cleanup-and-restoration" type="text" formControlName="descriptionOfCleanupAndRestoration" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'), 'description-of-cleanup-and-restoration-label', 'description-of-cleanup-and-restoration-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'))"></textarea>
     <app-error-message fieldId="description-of-cleanup-and-restoration-error" name="A description of cleanup and restoration" [control]="parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration')"></app-error-message>
 
     <label id="location-description-label" class="usa-input">Location of routes and starting and ending points for the proposed operations. <span class="required-fields-asterisk">*</span></label>
-    <p id="location-description-hint-text" class="help-text usa-form-hint">Please include trailheads, specific routes, latitude, longitude, and/or any landmarks that accurately describe the specific areas you will be using within the forest.</p>
+    <p id="location-description-hint-text" class="help-text usa-form-hint">Please include trailheads, specific routes, latitude, longitude, and/or any landmarks that accurately describe the specific areas you will be using within the forest (1000 character limit).</p>
     <textarea id="location-description" type="text" formControlName="locationDescription" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.locationDescription'), 'location-description-label location-description-hint-text', 'location-description-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.locationDescription'))"></textarea>

--- a/frontend/src/app/application-forms/fields/activity-description.component.ts
+++ b/frontend/src/app/application-forms/fields/activity-description.component.ts
@@ -45,22 +45,22 @@ export class ActivityDescriptionComponent implements OnInit {
       numberServiceDaysRequested: [this.dateStatus.dateTimeSpan, [alphanumericValidator(), Validators.maxLength(255)]],
       numberOfTrips: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
       partySize: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
-      locationDescription: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(400)]],
-      servicesProvided: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(400)]],
-      audienceDescription: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(400)]],
+      locationDescription: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(1000)]],
+      servicesProvided: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(1000)]],
+      audienceDescription: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(1000)]],
       needGovernmentFacilities: [false],
-      listOfGovernmentFacilities: ['', Validators.maxLength(400)],
+      listOfGovernmentFacilities: ['', Validators.maxLength(1000)],
       needTemporaryImprovements: [false],
-      listOfTemporaryImprovements: ['', Validators.maxLength(400)],
+      listOfTemporaryImprovements: ['', Validators.maxLength(1000)],
       haveMotorizedEquipment: [false],
-      statementOfMotorizedEquipment: ['', Validators.maxLength(400)],
+      statementOfMotorizedEquipment: ['', Validators.maxLength(1000)],
       haveLivestock: [false],
-      statementOfTransportationOfLivestock: ['', Validators.maxLength(400)],
+      statementOfTransportationOfLivestock: ['', Validators.maxLength(1000)],
       needAssignedSite: [false],
-      statementOfAssignedSite: ['', Validators.maxLength(400)],
+      statementOfAssignedSite: ['', Validators.maxLength(1000)],
       descriptionOfCleanupAndRestoration: [
         '',
-        [Validators.required, alphanumericValidator(), Validators.maxLength(400)]
+        [Validators.required, alphanumericValidator(), Validators.maxLength(1000)]
       ]
     });
     this.parentForm.addControl('activityDescriptionFields', activityDescription);

--- a/frontend/src/app/application-forms/fields/client-charges.component.html
+++ b/frontend/src/app/application-forms/fields/client-charges.component.html
@@ -2,7 +2,7 @@
   <fieldset>
     <legend>Client Charges</legend>
     <label class="usa-input" id="client-charges-label">Provide description of the fees you plan to charge your clients, and what those fees would cover. <span class="required-fields-asterisk">*</span></label>
-    <p id="client-charges-hint-text" class="help-text usa-form-hint">Your description of client fees will not impact what you would be charged for this permit. Charges for a temporary outfitting and guiding permit are based on a flat rate.</p>
+    <p id="client-charges-hint-text" class="help-text usa-form-hint">Your description of client fees will not impact what you would be charged for this permit. Charges for a temporary outfitting and guiding permit are based on a flat rate (1000 character limit).</p>
     <textarea id="client-charges" type="text" formControlName="clientCharges" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(tempOutfitterFields.controls.clientCharges, 'client-charges-label client-charges-hint-text', 'client-charges-error')"
       [attr.aria-invalid]="afs.hasError(tempOutfitterFields.controls.clientCharges)"></textarea>

--- a/frontend/src/app/application-forms/fields/noncommercial-fields.component.html
+++ b/frontend/src/app/application-forms/fields/noncommercial-fields.component.html
@@ -26,7 +26,10 @@
 
     <app-error-message fieldId="total-attendees-error" name="Total attendees" [control]="noncommercialFields"></app-error-message>
 
-    <label id="activity-description-label" class="usa-input">Description of proposed activity <span class="required-fields-asterisk">*</span></label>
+    <label id="activity-description-label" class="usa-input">Description of proposed activity
+      <span class="required-fields-asterisk">*</span>
+      <span class="help-text usa-form-hint character-limit-hint">(1000 character limit)</span>
+    </label>
     <textarea id="activity-description" formControlName="activityDescription" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(noncommercialFields.controls.activityDescription, 'activity-description-label', 'activity-description-error')"
       [attr.aria-invalid]="afs.hasError(noncommercialFields.controls.activityDescription)"></textarea>

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -114,7 +114,7 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
         advertisingDescription: ['', [alphanumericValidator(), Validators.maxLength(255)]],
         advertisingURL: ['', [Validators.required, urlValidator(), Validators.maxLength(255)]],
         noPromotionalWebsite: ['', Validators.maxLength(10)],
-        clientCharges: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(512)]],
+        clientCharges: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(1000)]],
         experienceList: ['', [alphanumericValidator(), Validators.maxLength(512)]]
       })
     });

--- a/frontend/src/sass/elements/_input.scss
+++ b/frontend/src/sass/elements/_input.scss
@@ -30,6 +30,9 @@ label {
   font-size: 17px;
   font-weight: 700;
 }
+label, span, .character-limit-hint{
+  font-weight: 500;
+}
 
 .form-directions {
   margin-bottom: 3em;


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1209     

This code update completes the 1209 card by updating all related .html, .ts, and .scss files to ensure that all description fields referenced in the 1209 card have their character validation expanded to 1000 characters. Additionally, hint text informing users of the 1000 character limit was added to each to the referenced fields as well.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author