### PR TITLE
Snyk fixes in dev

### DIFF
--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -5,11 +5,11 @@ ignore:
   SNYK-JS-MARKED-73637:
     - ngx-md > marked:
         reason: 'Medium severity, no remediation available.'
-        expires: '2020-03-25T18:04:57.495Z'
+        expires: '2020-06-25T18:04:57.495Z'
   SNYK-JS-MARKED-174116:
     - ngx-md > marked:
         reason: 'Medium severity, no remediation available.'
-        expires: '2020-03-25T18:04:57.495Z'
+        expires: '2020-06-25T18:04:57.495Z'
   SNYK-JS-COREJS-174627:
     - core-js:
         reason: No remediation available
@@ -17,50 +17,50 @@ ignore:
   SNYK-JS-LODASH-450202:
     - newrelic > async > lodash:
         reason: ignore for more days
-        expires: '2020-03-25T18:45:56.815Z'
+        expires: '2020-06-25T18:45:56.815Z'
   SNYK-JS-MARKED-451341:
     - ngx-md > marked:
         reason: no upgrade available
-        expires: '2020-04-25T23:02:43.714Z'
+        expires: '2020-06-25T23:02:43.714Z'
   SNYK-JS-HTTPSPROXYAGENT-469131:
     - newrelic > https-proxy-agent:
         reason: ignore for 30days
-        expires: '2020-04-25T18:45:56.816Z'
+        expires: '2020-06-25T18:45:56.816Z'
   SNYK-JS-ELLIPTIC-511941:
     - uswds > browserify > crypto-browserify > browserify-sign > elliptic:
         reason: ignore for more days
-        expires: '2020-04-25T18:26:03.902Z'
+        expires: '2020-06-25T18:26:03.902Z'
     - uswds > browserify > crypto-browserify > create-ecdh > elliptic:
         reason: ignore for more days
-        expires: '2020-04-25T18:26:03.902Z'
+        expires: '2020-06-25T18:26:03.902Z'
   SNYK-JS-ACORN-559469:
     - uswds > browserify > insert-module-globals > acorn-node > acorn:
         reason: None given
-        expires: '2020-04-12T20:19:47.857Z'
+        expires: '2020-06-12T20:19:47.857Z'
     - uswds > browserify > syntax-error > acorn-node > acorn:
         reason: None given
-        expires: '2020-04-12T20:19:47.857Z'
+        expires: '2020-06-12T20:19:47.857Z'
     - uswds > browserify > insert-module-globals > undeclared-identifiers > acorn-node > acorn:
         reason: None given
-        expires: '2020-04-12T20:19:47.857Z'
+        expires: '2020-06-12T20:19:47.857Z'
     - uswds > browserify > module-deps > detective > acorn:
         reason: None given
-        expires: '2020-04-12T20:19:47.857Z'
+        expires: '2020-06-12T20:19:47.857Z'
   SNYK-JS-MINIMIST-559764:
     - uswds > browserify > subarg > minimist:
         reason: None given
-        expires: '2020-04-12T20:19:47.858Z'
+        expires: '2020-06-12T20:19:47.858Z'
     - uswds > browserify > deps-sort > subarg > minimist:
         reason: None given
-        expires: '2020-04-12T20:19:47.858Z'
+        expires: '2020-06-12T20:19:47.858Z'
     - uswds > browserify > module-deps > subarg > minimist:
         reason: None given
-        expires: '2020-04-12T20:19:47.858Z'
+        expires: '2020-06-12T20:19:47.858Z'
     - webdriver-manager > minimist:
         reason: None given
-        expires: '2020-04-12T20:19:47.858Z'
+        expires: '2020-06-12T20:19:47.858Z'
   SNYK-JS-YARGSPARSER-560381:
     - uswds > yargs > yargs-parser:
         reason: Not ready to upgrade
-        expires: '2020-04-18T16:35:27.164Z'
+        expires: '2020-06-18T16:35:27.164Z'
 patch: {}

--- a/server/.snyk
+++ b/server/.snyk
@@ -136,11 +136,11 @@ ignore:
   SNYK-JS-MARKDOWNIT-459438:
     - jsdoc > markdown-it:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
   SNYK-JS-TREEKILL-536781:
     - snyk > snyk-sbt-plugin > tree-kill:
         reason: no upgrade path currenty
-        expires: '2020-05-08T15:38:05.011Z'
+        expires: '2020-06-08T15:38:05.011Z'
   SNYK-JS-HTTPSPROXYAGENT-469131:
     - newrelic > https-proxy-agent:
         reason: None given
@@ -148,58 +148,58 @@ ignore:
   SNYK-JS-ACORN-559469:
     - jsdom > acorn:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - jsdom > acorn-globals > acorn:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
   SNYK-JS-DOTPROP-543489:
     - snyk > configstore > dot-prop:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - snyk > update-notifier > configstore > dot-prop:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
   SNYK-JS-MINIMIST-559764:
     - snyk > update-notifier > latest-version > package-json > registry-auth-token > rc > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - snyk > update-notifier > latest-version > package-json > registry-url > rc > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - html-to-text > optimist > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - jsdoc > mkdirp > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - multer > mkdirp > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - svg2png > phantomjs-prebuilt > extract-zip > mkdirp > minimist:
         reason: None given
-        expires: '2020-04-12T20:20:22.049Z'
+        expires: '2020-06-12T20:20:22.049Z'
     - html-to-text > optimist > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
     - jsdoc > mkdirp > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
     - multer > mkdirp > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
     - svg2png > phantomjs-prebuilt > extract-zip > mkdirp > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
     - snyk > @snyk/update-notifier > latest-version > package-json > registry-auth-token > rc > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
     - snyk > @snyk/update-notifier > latest-version > package-json > registry-url > rc > minimist:
         reason: ignore for 30days
-        expires: '2020-04-12T20:45:56.284Z'
+        expires: '2020-06-12T20:45:56.284Z'
   SNYK-JS-YARGSPARSER-560381:
     - svg2png > yargs > yargs-parser:
         reason: No upgrade avail
-        expires: '2020-04-18T16:36:01.376Z'
+        expires: '2020-06-18T16:36:01.376Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:


### PR DESCRIPTION
Snyk vulnerability fix in dev.

Upgrade ngx-md@7.1.3 to ngx-md@8.0.0 to fix
  ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-JS-MARKED-174116] in marked@0.5.2
    introduced by ngx-md@7.1.3 > marked@0.5.2
  ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-JS-MARKED-73637] in marked@0.5.2
    introduced by ngx-md@7.1.3 > marked@0.5.2

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] Server actions captured by logs (manual)
- [ ] Documentation / readme.md updated (manual)
- [ ] API docs updated if need (manual)
- [ ] JSDocs updated (manual)
- [x] This code has been reviewed by someone other than the original author
