### PR TITLE
1165 incompatible browser warning

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,12 +2,6 @@
 <a tabindex="0" class="usa-skipnav" href="#skip-nav-target" (click)="util.gotoHashtag('skip-nav-target', $event)">Skip to main content</a>
 <header id="header" role="banner" class="usa-header usa-header-extended">
   <app-usa-banner></app-usa-banner>
-  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName() !== 'Chrome'">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Warning</h3>
-      <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience, please switch to Google Chrome.</p>
-    </div>
-  </div>
   <div class="usa-navbar">
     <app-page-header></app-page-header>
   </div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -17,8 +17,6 @@ export class AppComponent implements OnInit {
   apiurl = environment.apiUrl;
   currentUrl = '/';
   user: any;
-  browserName: string;
-  warningMessage: string;
   status = {
     heading: '',
     message: ''
@@ -28,7 +26,6 @@ export class AppComponent implements OnInit {
     public authentication: AuthenticationService,
     public util: UtilService,
     private meta: Meta) {
-    this.warningMessage = '',
     this.meta.addTag(
       { name: 'keywords',
        content: 'Forest Service, permitting, permits, christmas trees, national forest, national forests'
@@ -52,45 +49,6 @@ export class AppComponent implements OnInit {
       }
     });
   }
-
-  getBrowserName() {
-    const  userAgent = navigator.userAgent;
-    let browserInfo = userAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
-    let parsedBrowserInfo;
-
-        if (/trident/i.test(browserInfo[1])) {
-
-          parsedBrowserInfo = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
-
-          return { name: 'IE', version: (parsedBrowserInfo[1] || '') };
-
-        }
-
-    if (browserInfo[1] === 'Chrome') {
-
-        parsedBrowserInfo = userAgent.match (/\bOPR|Edge\/(\d+)/);
-
-        if (parsedBrowserInfo != null)   {
-
-            return { name: 'Opera', version: parsedBrowserInfo[1] };
-
-          }
-
-        }
-
-      browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
-
-    if (( parsedBrowserInfo = userAgent.match(/version\/(\d+)/i)) != null) {
-
-      browserInfo.splice(1, 1, parsedBrowserInfo[1]);
-
-    }
-
-     this.browserName = browserInfo[0];
-
-     return this.browserName;
-
- }
 
   /**
    *  Set status message

--- a/frontend/src/app/shared/header/header.component.html
+++ b/frontend/src/app/shared/header/header.component.html
@@ -1,5 +1,5 @@
 <div id="site-header-navbar" class="site-header-navbar">
-  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName() === 'Chrome'">
+  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName() !== 'Chrome'">
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading">Warning</h3>
       <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience please switch to Google Chrome.</p>

--- a/frontend/src/app/shared/header/header.component.html
+++ b/frontend/src/app/shared/header/header.component.html
@@ -1,4 +1,10 @@
 <div id="site-header-navbar" class="site-header-navbar">
+  <div class="usa-alert usa-alert-warning application-deadline-warning application-browser-alert" aria-role="dialog" aria-label="warning" *ngIf="getBrowserName() === 'Chrome'">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">Warning</h3>
+      <p class="usa-alert-text">The browser your are currently using is not compatible with the Open Forest website. For a better experience please switch to Google Chrome.</p>
+    </div>
+  </div>
   <div class="usa-logo" id="logo">
     <div class="fs-branding">
       <a class="float-left" href="//usda.gov">

--- a/frontend/src/app/shared/header/header.component.ts
+++ b/frontend/src/app/shared/header/header.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { Meta } from '@angular/platform-browser';
 
 @Component({
@@ -10,7 +9,7 @@ export class PageHeaderComponent {
   browserName: string;
   warningMessage: string;
 
-  constructor(public router: Router,
+  constructor(
     private meta: Meta) {
     this.warningMessage = '';
   }

--- a/frontend/src/app/shared/header/header.component.ts
+++ b/frontend/src/app/shared/header/header.component.ts
@@ -1,8 +1,57 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-page-header',
   templateUrl: './header.component.html'
 })
-export class PageHeaderComponent {}
+export class PageHeaderComponent {
+  browserName: string;
+  warningMessage: string;
+
+  constructor(public router: Router,
+    private meta: Meta) {
+    this.warningMessage = ''
+  }
+
+  getBrowserName() {
+    const  userAgent = navigator.userAgent;
+    let browserInfo = userAgent.match (/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+    let parsedBrowserInfo;
+
+        if (/trident/i.test(browserInfo[1])) {
+
+          parsedBrowserInfo = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
+
+          return { name: 'IE', version: (parsedBrowserInfo[1] || '') };
+
+        }
+
+    if (browserInfo[1] === 'Chrome') {
+
+        parsedBrowserInfo = userAgent.match (/\bOPR|Edge\/(\d+)/);
+
+        if (parsedBrowserInfo != null)   {
+
+            return { name: 'Opera', version: parsedBrowserInfo[1] };
+
+          }
+
+        }
+
+      browserInfo = browserInfo[2] ? [browserInfo[1], browserInfo[2]] : [navigator.appName, navigator.appVersion, '-?'];
+
+    if (( parsedBrowserInfo = userAgent.match(/version\/(\d+)/i)) != null) {
+
+      browserInfo.splice(1, 1, parsedBrowserInfo[1]);
+
+    }
+
+     this.browserName = browserInfo[0];
+
+     return this.browserName;
+
+ }
+
+}

--- a/frontend/src/app/shared/header/header.component.ts
+++ b/frontend/src/app/shared/header/header.component.ts
@@ -12,7 +12,7 @@ export class PageHeaderComponent {
 
   constructor(public router: Router,
     private meta: Meta) {
-    this.warningMessage = ''
+    this.warningMessage = '';
   }
 
   getBrowserName() {

--- a/frontend/src/sass/elements/_alerts.scss
+++ b/frontend/src/sass/elements/_alerts.scss
@@ -12,12 +12,3 @@
 .usa-alert a.usa-button:hover {
   color: white;
 }
-
-.application-browser-alert {
-  margin-top: 0rem;
-  max-width: 115rem;
-  @media (min-width: $large-screen) {
-    margin-left: 32rem;
-    margin-right: 32rem;
-  }
-}


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1165    

This code update adds additional style changes to complete the 1165 card by updating the app.component html and ts files along with the _alert.scss file in order to determine what browser a user is accessing Open Forest through and display a warning banner if they're using anything but Chrome. Additionally, the .ts and .html files being used to achieve the desired functionality was changed in order to a better outcome from a design perspective.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author