### PR TITLE
1229 email subject special uses

### DIFF
--- a/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
+++ b/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
@@ -5,7 +5,7 @@ module.exports = (application, defaultApplicationDetails, reviewTime) => {
 
   return {
     to: application.applicantInfoEmailAddress,
-    subject: `Your ${util.camelCaseToRegularForm(application.type)} Open Forest permit application has been submitted for review!`,
+    subject: `Your permit application has been submitted for review!`,
     body: `
       Submitted for review!
       **************************************

--- a/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
+++ b/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
@@ -5,7 +5,7 @@ module.exports = (application, defaultApplicationDetails, reviewTime) => {
 
   return {
     to: application.applicantInfoEmailAddress,
-    subject: `Your permit application has been submitted for review!`,
+    subject: `Your ${application.type === 'tempOutfitters' ? 'Temporary Outfitting and Guiding' : 'Non-Commercial Group Use'} permit application has been submitted for review!`,
     body: `
       Submitted for review!
       **************************************

--- a/server/test/email-templates.spec.es6
+++ b/server/test/email-templates.spec.es6
@@ -29,7 +29,7 @@ describe('Special use email templates', () =>{
     it('should build an object of email content for noncommercial app submission to user', () => {
       application.status = 'Submitted';
       const emailContent = emails.noncommercialApplicationSubmittedConfirmation(application);
-      const specialUseSubjectCustom = 'Your Noncommercial Open Forest permit application has been submitted for review!';
+      const specialUseSubjectCustom = 'Your permit application has been submitted for review!';
 
       expect(emailContent.subject).to.be.eq(specialUseSubjectCustom);
       expect(emailContent).to.have.all.keys('to','subject', 'body', 'html');
@@ -126,7 +126,7 @@ describe('Special use email templates', () =>{
 
     it('should build an object of email content for temp outfitter app submission to user', () => {
       application.status = 'Submitted';
-      const specialUseSubjectCustom = 'Your Temp outfitters Open Forest permit application has been submitted for review!';
+      const specialUseSubjectCustom = 'Your permit application has been submitted for review!';
       application.tempOutfitterFieldsActDescFieldsEndDateTime = '2018-12-14T21:00:00Z';
       const emailContent = emails.tempOutfitterApplicationSubmittedConfirmation(application);
 

--- a/server/test/email-templates.spec.es6
+++ b/server/test/email-templates.spec.es6
@@ -29,7 +29,7 @@ describe('Special use email templates', () =>{
     it('should build an object of email content for noncommercial app submission to user', () => {
       application.status = 'Submitted';
       const emailContent = emails.noncommercialApplicationSubmittedConfirmation(application);
-      const specialUseSubjectCustom = 'Your permit application has been submitted for review!';
+      const specialUseSubjectCustom = 'Your Non-Commercial Group Use permit application has been submitted for review!';
 
       expect(emailContent.subject).to.be.eq(specialUseSubjectCustom);
       expect(emailContent).to.have.all.keys('to','subject', 'body', 'html');
@@ -126,7 +126,7 @@ describe('Special use email templates', () =>{
 
     it('should build an object of email content for temp outfitter app submission to user', () => {
       application.status = 'Submitted';
-      const specialUseSubjectCustom = 'Your permit application has been submitted for review!';
+      const specialUseSubjectCustom = 'Your Temporary Outfitting and Guiding permit application has been submitted for review!';
       application.tempOutfitterFieldsActDescFieldsEndDateTime = '2018-12-14T21:00:00Z';
       const emailContent = emails.tempOutfitterApplicationSubmittedConfirmation(application);
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1229 

This code update changes the subject line of the email that is automatically sent to the user and admins when the user submits their NCGU or TOG application. The language of the subject line was made more generic in order to accommodate any new application types that might be potentially added in the future.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author