### PR TITLE
1206 phone number error text update

### DIFF
--- a/frontend/src/app/application-forms/fields/phone-number.component.ts
+++ b/frontend/src/app/application-forms/fields/phone-number.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ApplicationFieldsService } from '../_services/application-fields.service';
-import { phoneNumberMinValidator } from '../validators/phone-number-min-length-validation';
-import { phoneNumberMaxValidator } from '../validators/phone-number-max-length-validation';
+import { phoneNumberMinMaxValidator } from '../validators/phone-number-min-max-validation';
 
 @Component({
   selector: 'app-phone-number',
@@ -34,7 +33,7 @@ export class PhoneNumberComponent implements OnInit {
       extension: [, [Validators.minLength(1), Validators.maxLength(6)]],
       number: [null, Validators.maxLength(4)],
       prefix: [null, Validators.maxLength(3)],
-      tenDigit: ['', [Validators.required, phoneNumberMinValidator(), phoneNumberMaxValidator()]]
+      tenDigit: ['', [Validators.required, phoneNumberMinMaxValidator()]]
     });
     this.parentForm.addControl('dayPhone', dayPhone);
 
@@ -53,7 +52,7 @@ export class PhoneNumberComponent implements OnInit {
       this.parentForm.get('eveningPhone.extension').setValidators([Validators.minLength(1), Validators.maxLength(6)]);
       this.parentForm
         .get('eveningPhone.tenDigit')
-        .setValidators([Validators.required, phoneNumberMinValidator(), phoneNumberMaxValidator()]);
+        .setValidators([Validators.required, phoneNumberMinMaxValidator()]);
     } else {
       this.parentForm.get('eveningPhone.extension').setValidators(null);
       this.parentForm.get('eveningPhone.tenDigit').setValidators(null);

--- a/frontend/src/app/application-forms/validators/phone-number-min-max-validation.ts
+++ b/frontend/src/app/application-forms/validators/phone-number-min-max-validation.ts
@@ -1,0 +1,24 @@
+import { FormControl, ValidatorFn } from '@angular/forms';
+
+export function phoneNumberMinMaxValidator(): ValidatorFn {
+  return (control: FormControl): { [key: string]: any } => {
+    const val = control.value;
+    if (val && val.length) {
+      const phoneNumberRegex = /^[0-9]*$/;
+      const valid = phoneNumberRegex.test(val);
+      if (!valid) {
+        return {numberRequirement: true};
+      }
+      else if (valid && val.length < 10) {
+        return {phoneNumberMinRequirement: true};
+      }
+      else if (valid && val.length > 10) {
+        return {phoneNumberMaxRequirement: true};
+      }
+      else{
+        return null;
+      }
+    }
+  };
+}
+

--- a/frontend/src/sass/pages/_application-view.scss
+++ b/frontend/src/sass/pages/_application-view.scss
@@ -131,13 +131,27 @@
 }
 
 .phone-number-section {
+  position: relative;
   display: flex;
   flex-direction: row;
   align-items: flex-end;
-  @media (min-width: 600px) {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-  }
 
+  @media (max-width: 600px) {
+     position: unset;
+     display: flex;
+     flex-direction: column;
+     align-items: unset;
+   }
 }
+
+  .phone-extension-wrapper {
+    position: absolute;
+    top: 2.2rem;
+    left: 30rem;
+
+    @media (max-width: 600px) {
+      position: unset;
+      top: unset;
+      left: unset;
+    }
+  }

--- a/server/test/tempoutfitter-controllers.spec.es6
+++ b/server/test/tempoutfitter-controllers.spec.es6
@@ -90,26 +90,26 @@ describe('tempoutfitter controllers', () => {
         .expect(400, done);
     });
 
-    it('POST should return a 400 status code and 9 errors when the activity description fields are all over 400 characters', (done) => {
+    it('POST should return a 400 status code and 9 errors when the activity description fields are all over 1000 characters', (done) => {
       const permitApplication = tempOutfitterPermitApplicationFactory.create();
-      permitApplication.tempOutfitterFields.activityDescriptionFields.audienceDescription = util.getRandomString(401);
+      permitApplication.tempOutfitterFields.activityDescriptionFields.audienceDescription = util.getRandomString(1001);
       permitApplication.tempOutfitterFields.activityDescriptionFields.descriptionOfCleanupAndRestoration = util.getRandomString(
-        401
+        1001
       );
       permitApplication.tempOutfitterFields.activityDescriptionFields.listOfGovernmentFacilities = util.getRandomString(
-        401
+        1001
       );
       permitApplication.tempOutfitterFields.activityDescriptionFields.listOfTemporaryImprovements = util.getRandomString(
-        401
+        1001
       );
-      permitApplication.tempOutfitterFields.activityDescriptionFields.locationDescription = util.getRandomString(401);
-      permitApplication.tempOutfitterFields.activityDescriptionFields.servicesProvided = util.getRandomString(401);
-      permitApplication.tempOutfitterFields.activityDescriptionFields.statementOfAssignedSite = util.getRandomString(401);
+      permitApplication.tempOutfitterFields.activityDescriptionFields.locationDescription = util.getRandomString(1001);
+      permitApplication.tempOutfitterFields.activityDescriptionFields.servicesProvided = util.getRandomString(1001);
+      permitApplication.tempOutfitterFields.activityDescriptionFields.statementOfAssignedSite = util.getRandomString(1001);
       permitApplication.tempOutfitterFields.activityDescriptionFields.statementOfMotorizedEquipment = util.getRandomString(
-        401
+        1001
       );
       permitApplication.tempOutfitterFields.activityDescriptionFields.statementOfTransportationOfLivestock = util.getRandomString(
-        401
+        1001
       );
       agent
         .post(tempoutfitterUrl)


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1206  

This code update address a few things missed in the original solution for the 1206 card by removing the phone-number-min-length and phone-number-max-length components and replacing them with one component to handle all logic for the min/max validation. Accordingly, additional changes were made to the phone-number.component.ts and .html files to accommodate the move to a singular min/max validator. Finally, styling changes were made to ensure consistent user experience of the TOG application across all screen sizes and when the phone-number error text is thrown.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author