### PR TITLE
1182 whitelist parity plus poc roles

### DIFF
--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -391,16 +391,16 @@ util.getAdminForests = (adminUsername) => {
   return [];
 };
 
-util.getForestsByRegion = (region) => {
-  const forests = forestService.getForests();
-  const regionForests = [];
-  for (let i = 0; i < forests.length; i += 1) {
-    if (forests[i].region === region) {
-      regionForests.push(forests[i].forestAbbr);
-    }
-  }
-  return regionForests;
-};
+// util.getForestsByRegion = (region) => {
+//   const forests = forestService.getForests();
+//   const regionForests = [];
+//   for (let i = 0; i < forests.length; i += 1) {
+//     if (forests[i].region === region) {
+//       regionForests.push(forests[i].forestAbbr);
+//     }
+//   }
+//   return regionForests;
+// };
 
 /**
  * Return an array of forests (short names) that are parsed out from the provided eAuth approles string
@@ -414,11 +414,9 @@ util.getEauthForests = (approles) => {
 
   // check each role for a forest
   for (let i = 0; i < roles.length; i += 1) {
-    // if (roles[i].includes('FS_Open-Forest_R')) {
-    //   const region = parseInt(roles[i].replace('FS_Open-Forest_R', ''), 10);
-    //   forests = util.getForestsByRegion(region);
-    // } else
-    if (['FS_Open-Forest', 'FS_OpenForest'].some(role => roles[i].includes(role))) {
+    if (roles[i].includes('FS_Open-Forest_R')) {
+      forests = ['all'];
+    } else if (['FS_Open-Forest', 'FS_OpenForest'].some(role => roles[i].includes(role))) {
       // strip the role down to just a forest
       forest = roles[i].replace('-POC2', '')
         .replace('_POC2', '')
@@ -459,11 +457,9 @@ util.getPOC2Forests = (approles) => {
 
   // check each role for a forest
   for (let i = 0; i < roles.length; i += 1) {
-    // if (roles[i].includes('FS_Open-Forest_R')) {
-    //   const region = parseInt(roles[i].replace('FS_Open-Forest_R', ''), 10);
-    //   forests = util.getForestsByRegion(region);
-    // } else
-    if (['POC1', 'POC2'].some(role => roles[i].includes(role))) {
+    if (roles[i].includes('FS_Open-Forest_R')) {
+      forests = ['all'];
+    } else if (['POC1', 'POC2'].some(role => roles[i].includes(role))) {
       // strip the role down to just a forest
       forest = roles[i].replace('-POC2', '')
         .replace('_POC2', '')
@@ -500,11 +496,9 @@ util.getPOC1Forests = (approles) => {
 
   // check each role for a forest
   for (let i = 0; i < roles.length; i += 1) {
-    // if (roles[i].includes('FS_Open-Forest_R')) {
-    //   const region = parseInt(roles[i].replace('FS_Open-Forest_R', ''), 10);
-    //   forests = util.getForestsByRegion(region);
-    // } else
-    if (roles[i].includes('POC1')) {
+    if (roles[i].includes('FS_Open-Forest_R')) {
+      forests = ['all'];
+    } else if (roles[i].includes('POC1')) {
       // strip the role down to just a forest
       forest = roles[i].replace('-POC2', '')
         .replace('_POC2', '')

--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -15,7 +15,7 @@ const dbConfig = require('../../.sequelize.js');
 const vcapConstants = require('../vcap-constants.es6');
 const logger = require('../services/logger.es6');
 
-const forestService = require('./forest.service.es6');
+// const forestService = require('./forest.service.es6');
 
 const util = {};
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1182 

This pull request brings us to parity with the whitelist functionality for admin roles, with the additional functionality for POC1 and POC2 roles.

Regional roles were added to the scope of this issue after work was already underway -- after further assessment the decision was to push this through and address regional roles in a proper followup issue and prevent scope creep. **currently users with regional roles will be assigned all forests.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
