### PR TITLE
Add hint text "1000 character limit"

### DIFF
--- a/frontend/src/app/application-forms/fields/activity-description.component.html
+++ b/frontend/src/app/application-forms/fields/activity-description.component.html
@@ -83,7 +83,7 @@
     </ng-container>
 
     <label id="description-of-cleanup-and-restoration-label" class="usa-input">Description of cleanup and restoration during and after the proposed operations. <span class="required-fields-asterisk">*</span></label>
-    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide a brief description of your plan for cleanup and restr after your event or trip is complete (1000 character limit).</p>
+    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide a brief description of your plan for cleanup and restoration after your event or trip is complete (1000 character limit).</p>
     <textarea id="description-of-cleanup-and-restoration" type="text" formControlName="descriptionOfCleanupAndRestoration" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'), 'description-of-cleanup-and-restoration-label', 'description-of-cleanup-and-restoration-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'))"></textarea>

--- a/frontend/src/app/application-forms/fields/activity-description.component.html
+++ b/frontend/src/app/application-forms/fields/activity-description.component.html
@@ -90,7 +90,7 @@
     <app-error-message fieldId="description-of-cleanup-and-restoration-error" name="A description of cleanup and restoration" [control]="parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration')"></app-error-message>
 
     <label id="location-description-label" class="usa-input">Location of routes and starting and ending points for the proposed operations. <span class="required-fields-asterisk">*</span></label>
-    <p id="location-description-hint-text" class="help-text usa-form-hint">Please include trailheads, specific routes, latitude, longitude, and/or any landmarks that accurately describe the specific areas you will be using within the forest.</p>
+    <p id="location-description-hint-text" class="help-text usa-form-hint">Please include trailheads, specific routes, latitude, longitude, and/or any landmarks that accurately describe the specific areas you will be using within the forest (1000 character limit).</p>
     <textarea id="location-description" type="text" formControlName="locationDescription" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.locationDescription'), 'location-description-label location-description-hint-text', 'location-description-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.locationDescription'))"></textarea>

--- a/frontend/src/app/application-forms/fields/activity-description.component.html
+++ b/frontend/src/app/application-forms/fields/activity-description.component.html
@@ -26,6 +26,7 @@
     <app-error-message fieldId="services-provided-error" name="A list of services provided" [control]="parentForm.get('activityDescriptionFields.servicesProvided')"></app-error-message>
 
     <label id="audience-description-label" class="usa-input" for="audience-description">Description of your client base or audience. <span class="required-fields-asterisk">*</span></label>
+    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide an overview of your client base (1000 character limit).</p>
     <textarea id="audience-description" type="text" formControlName="audienceDescription" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.audienceDescription'), 'audience-description-label', 'audience-description-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.audienceDescription'))"></textarea>
@@ -82,6 +83,7 @@
     </ng-container>
 
     <label id="description-of-cleanup-and-restoration-label" class="usa-input">Description of cleanup and restoration during and after the proposed operations. <span class="required-fields-asterisk">*</span></label>
+    <p id="services-provided-hint-text" class="help-text usa-form-hint">Please provide a brief description of your plan for cleanup and restr after your event or trip is complete (1000 character limit).</p>
     <textarea id="description-of-cleanup-and-restoration" type="text" formControlName="descriptionOfCleanupAndRestoration" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'), 'description-of-cleanup-and-restoration-label', 'description-of-cleanup-and-restoration-error')"
       [attr.aria-invalid]="afs.hasError(parentForm.get('activityDescriptionFields.descriptionOfCleanupAndRestoration'))"></textarea>


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1209     

This code update completes the 1209 card by updating all related .html, .ts, and .scss files to ensure that all description fields referenced in the 1209 card have their character validation expanded to 1000 characters. Additionally, hint text informing users of the 1000 character limit was added to each to the referenced fields as well.

*** Note: this is the second iteration of this PR in order to add in some hint text that was missed in the first go around.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author