### PR TITLE
1387-Bold-Title-Descriptions

### DIFF
--- a/frontend/src/sass/elements/_input.scss
+++ b/frontend/src/sass/elements/_input.scss
@@ -31,7 +31,7 @@ label {
   font-weight: 700;
 }
 
-label, span, .character-limit-hint{
+span, .character-limit-hint{
   font-weight: 500;
 }
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1387  

This code update reverts the labels of the TOG and NCGU applications to their original font-weight so that they appear bolded in on the site.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [ ] This code has been reviewed by someone other than the original author﻿## ﻿## 