### PR TITLE
1386-Reduce-Character-Limits

### DIFF
--- a/frontend/src/app/application-forms/fields/organization-name.component.html
+++ b/frontend/src/app/application-forms/fields/organization-name.component.html
@@ -1,9 +1,9 @@
 <ng-container [formGroup]="applicantInfo">
   <label id="organization-name-label" class="usa-input">{{ name }} <span class="required-fields-asterisk">*</span></label>
-  <p id="organization-name-hint-text" class="help-text usa-form-hint">NOTE: The {{ name }} field only allows 30 characters for input.</p>
   <input id="organization-name" type="text" formControlName="organizationName" [attr.aria-required]="required ? 'true' : null"
   [attr.aria-labelledby]="afs.labelledBy(applicantInfo.controls.organizationName, 'organization-name-label', 'organization-name-error')"
   [attr.aria-invalid]="afs.hasError(applicantInfo.controls.organizationName)"
   />
+  <p id="organization-name-hint-text" class="help-text usa-form-hint">Only 30 characters allowed.</p>
   <app-error-message fieldId="organization-name-error" name="Organization name" [control]="applicantInfo.controls.organizationName"></app-error-message>
 </ng-container>

--- a/frontend/src/sass/elements/_input.scss
+++ b/frontend/src/sass/elements/_input.scss
@@ -69,11 +69,6 @@ label, span, .character-limit-hint{
   margin-right: 1.5rem;
 }
 
-// .number-input-wrapper {
-//   display: flex;
-//   flex-direction: row;
-// }
-
 input.number-input-sizing {
   width: 9rem;
 }
@@ -178,4 +173,8 @@ input[disabled] {
   font-size: 17px;
   font-weight: bold;
   font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+}
+
+#organization-name-hint-text {
+  margin-top: 0rem;
 }


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1386  

This code update reduces the character limit on the "Business name" and "Organization name" fields. Additionally hint text was added to warn the user that the character restriction is in place and an error message is thrown if the user exceeds those character limits.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author﻿## 