### PR TITLE
update samesite for express cookies

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -62,7 +62,8 @@ app.use(
     cookie: {
       secure: true,
       httpOnly: true,
-      domain
+      domain,
+      sameSite: 'none'
     }
   })
 );


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1418 

Please note if fully resolves the issue per the acceptance criteria: Yes

*Changes express session samesite attribute to correct chrome 80 change*

## Impacted Areas of the Site
- any 3rd party re-route that was blocking cookies due to chrome 80 change

## This pull request changes...
- [x] SameSite attributes introduced in google chrome 80

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [x] Server actions captured by logs (manual)
- [x] Documentation / readme.md updated (manual)
- [x] API docs updated if need (manual)
- [x] JSDocs updated (manual)
- [ ] This code has been reviewed by someone other than the original author
