### PR TITLE
1354 map link

### DIFF
--- a/frontend/src/app/esri-map/esri-map.component.scss
+++ b/frontend/src/app/esri-map/esri-map.component.scss
@@ -1,11 +1,9 @@
 /* import the required JSAPI css */
-// @import 'https://js.arcgis.com/4.10/esri/css/main.css';
-@import 'https://js.arcgis.com/4.10/esri/themes/dark-green/main.css';
+@import 'https://js.arcgis.com/4.10/esri/css/main.css';
 // @import '../../../node_modules/arcgis-js-api/themes/dark/main.scss';
 .esri-view {
   height: 650px;
 }
-
 
 $search_width: 240px !default;
 

--- a/frontend/src/app/esri-map/esri-map.component.ts
+++ b/frontend/src/app/esri-map/esri-map.component.ts
@@ -12,7 +12,9 @@ export class EsriMapComponent implements AfterViewInit {
 
   @ViewChild('mapViewNode') private mapViewEl: ElementRef;
 
-  constructor(public router: Router) { }
+  constructor(
+    public router: Router
+    ) { }
 
   ngAfterViewInit() {
     loadModules([
@@ -20,9 +22,6 @@ export class EsriMapComponent implements AfterViewInit {
       'esri/views/MapView',
       'esri/layers/GeoJSONLayer',
       'esri/widgets/Search',
-      // 'esri/layers/CSVLayer',
-      // 'esri/renderers/UniqueValueRenderer',
-      // 'esri/layers/WMSLayer'
     ])
       .then(([EsriMap, MapView, GeoJSONLayer, Search]) => {
         const map = new EsriMap({
@@ -59,10 +58,32 @@ export class EsriMapComponent implements AfterViewInit {
         });
 
         function checkForest (feature) {
-          const mbsForest = 'Mt. Baker-Snoqualmie National Forest';
-          const common = feature.graphic.attributes.COMMONNAME;
-          const route = document.location.origin;
-          if (common === mbsForest) {
+          let fwfRoute;
+          let fwf;
+          var mbsForest = 'Mt. Baker-Snoqualmie National Forest';
+          var common = feature.graphic.attributes.COMMONNAME;
+          var route = document.location.origin;
+          var fuelwoodForest = [
+            {fname: 'Idaho Panhandle National Forests', fshort: 'ipnf'},
+            {fname: 'Flathead National Forest', fshort: 'flathead'},
+            {fname: 'Chattahoochee-Oconee National Forest', fshort: 'conf'},
+            {fname: 'George Washington & Jefferson National Forest', fshort: 'gwj'},
+            {fname: 'Shoshone National Forest', fshort: 'shoshone'},
+            {fname: 'Hiawatha National Forest', fshort: 'hiawatha'},
+            {fname: 'Grand Mesa Uncompahgre & Gunnison National Forest', fshort: 'gmug'},
+          ];
+          for (var i = 0; i < fuelwoodForest.length; i++) {
+            if (common === fuelwoodForest[i].fname) {
+              fwf = fuelwoodForest[i].fname;
+              fwfRoute = fuelwoodForest[i].fshort
+            }
+          }
+          if (common === fwf){
+            return `<p>The {COMMONNAME} is part of {ADMINFORESTNAME}</p>` +
+            `<p>For more information about this forest please visit <a href={URL}>{URL}</a>` +
+            `<h3 class='show-white'>Available Permits</h3>` +
+            `<h3><a href='` + route + `/firewood/forests/` + fwfRoute + `'>Fuelwood Permits</a></h3>` 
+          } else if (common === mbsForest) {
             return `<p>The {COMMONNAME} is part of {ADMINFORESTNAME}</p>` +
             `<p>For more information about this forest please visit <a href={URL}>{URL}</a>` +
             `<h3>Available Permits</h3>` +
@@ -72,7 +93,7 @@ export class EsriMapComponent implements AfterViewInit {
             return `<p>The {COMMONNAME} is part of {ADMINFORESTNAME}</p>` +
             `<p>For more information about this forest please visit <a href={URL}>{URL}</a>`;
           }
-        }
+      }
 
       const searchWidget = new Search({
         mapView: mapView,

--- a/frontend/src/app/esri-map/esri-map.component.ts
+++ b/frontend/src/app/esri-map/esri-map.component.ts
@@ -60,10 +60,10 @@ export class EsriMapComponent implements AfterViewInit {
         function checkForest (feature) {
           let fwfRoute;
           let fwf;
-          var mbsForest = 'Mt. Baker-Snoqualmie National Forest';
-          var common = feature.graphic.attributes.COMMONNAME;
-          var route = document.location.origin;
-          var fuelwoodForest = [
+          const mbsForest = 'Mt. Baker-Snoqualmie National Forest';
+          const common = feature.graphic.attributes.COMMONNAME;
+          const route = document.location.origin;
+          const fuelwoodForest = [
             {fname: 'Idaho Panhandle National Forests', fshort: 'ipnf'},
             {fname: 'Flathead National Forest', fshort: 'flathead'},
             {fname: 'Chattahoochee-Oconee National Forest', fshort: 'conf'},
@@ -72,17 +72,17 @@ export class EsriMapComponent implements AfterViewInit {
             {fname: 'Hiawatha National Forest', fshort: 'hiawatha'},
             {fname: 'Grand Mesa Uncompahgre & Gunnison National Forest', fshort: 'gmug'},
           ];
-          for (var i = 0; i < fuelwoodForest.length; i++) {
+          for (let i = 0; i < fuelwoodForest.length; i++) {
             if (common === fuelwoodForest[i].fname) {
               fwf = fuelwoodForest[i].fname;
-              fwfRoute = fuelwoodForest[i].fshort
+              fwfRoute = fuelwoodForest[i].fshort;
             }
           }
-          if (common === fwf){
+          if (common === fwf) {
             return `<p>The {COMMONNAME} is part of {ADMINFORESTNAME}</p>` +
             `<p>For more information about this forest please visit <a href={URL}>{URL}</a>` +
             `<h3 class='show-white'>Available Permits</h3>` +
-            `<h3><a href='` + route + `/firewood/forests/` + fwfRoute + `'>Fuelwood Permits</a></h3>` 
+            `<h3><a href='` + route + `/firewood/forests/` + fwfRoute + `'>Fuelwood Permits</a></h3>`;
           } else if (common === mbsForest) {
             return `<p>The {COMMONNAME} is part of {ADMINFORESTNAME}</p>` +
             `<p>For more information about this forest please visit <a href={URL}>{URL}</a>` +


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1354 

Please note if fully resolves the issue per the acceptance criteria: Yes

*Updating ESRI maps to include links to forests with fuelwood permits. Coding style is dated in order to function correctly with esri popuptemplate. The esri popuptemplate function call does not accept additional parameters or fat arrow functions*

## Impacted Areas of the Site
- /home


## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [ ] This code has been reviewed by someone other than the original author
