### PR TITLE
E2e troubleshoot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,11 +287,11 @@ docker.image('circleci/node:8.15.1-browsers').withRun() {
                   npm install
                   cd ../server
                   
-		   npm cache verify
+		#   npm cache verify
 		   npm config rm proxy
 		   npm config rm https-proxy
-	    	   npm config set registry http://registry.npmjs.org/
-	    	   npm config set strict-ssl false                    
+	    	   npm config set registry https://registry.npmjs.org/
+	   # 	   npm config set strict-ssl false                    
                    npm i -D webdriver-manager
                    rm -rf node_modules
                    npm install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,6 +287,7 @@ docker.image('circleci/node:8.15.1-browsers').withRun() {
                   npm install
                   cd ../server
                   
+		   npm cache verify
 		   npm config rm proxy
 		   npm config rm https-proxy
 	    	   npm config set registry http://registry.npmjs.org/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,7 @@ stage('run-sonarqube'){
       '''
 	def scannerhome = tool 'SonarQubeScanner';
         withSonarQubeEnv('SonarQube') {
-          sh label: '', script: '''/home/Jenkins/tools/hudson.plugins.sonar.SonarRunnerInstallation/SonarQubeScanner/bin/sonar-scanner -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_PROJECT_NAME -Dsonar.sources=. -Dsonar.branch.name=$GIT_BRANCH -Dsonar.exclusions=frontend/node_modules/**,frontend/dist/**,frontend/e2e/**,,server/node_modules/**,server/docs/**,server/frontend-assets/**,server/dba/**,server/test/**,docs/**'''
+          sh label: '', script: '''/home/Jenkins/tools/hudson.plugins.sonar.SonarRunnerInstallation/SonarQubeScanner/bin/sonar-scanner -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_PROJECT_NAME -Dsonar.sources=. -Dsonar.branch.name=$GIT_BRANCH -Dsonar.exclusions=frontend/node_modules/**,frontend/dist/**,frontend/e2e/**,server/node_modules/**,server/docs/**,server/frontend-assets/**,server/dba/**,server/test/**,docs/**'''
       	  //sh 'rm -rf sonarqubereports'
           //sh 'mkdir sonarqubereports'
   	  //sh 'sleep 30'


### PR DESCRIPTION
﻿## Summary
Update to exisiting jenkinsfile with update to network registry.

Please note if fully resolves the issue per the acceptance criteria: Y/N Y

*Describe the pull request here, including any supplemental information needed to understand it.*

Operations team last week blocked any outgoing http connections from the Jenkins server. They allow only https connections now. We were using http://registry.npmjs.org url for downloading webdriver manager. This was timing out during e2e testing. Update this to https and it works fine now.
## Optional Screenshots
 
## This pull request changes...
- [x] npm config set registry https://registry.npmjs.org/ from http://registry.npmjs.org/

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [x] Server actions captured by logs (manual)
- [x] Documentation / readme.md updated (manual)
- [x] API docs updated if need (manual)
- [x] JSDocs updated (manual)
- [x] This code has been reviewed by someone other than the original author
