### PR TITLE
update christmas tree redirect

### DIFF
--- a/frontend/src/app/main-landing/main-landing.component.html
+++ b/frontend/src/app/main-landing/main-landing.component.html
@@ -44,12 +44,32 @@
   </div>
 
 
-  <div class="usa-width-one-whole wrapper" id="notsure-background">
-    <div class="option-content">
-      <h2>I’m not sure which permit I need...</h2>
-      <p>If you’re not sure about what kind of permit you need, click on the button below to answer a few questions. We will guide you to the permit that best meets your needs.</p>
+  <div class="help-pick-flex" id="help-pick-background">
+    <div class="small-col small-col-left">
+      <span class="hero-icon">
+        <i class="far fa-question-circle usa-ico"></i>
+      </span>
     </div>
-    <a id="help-find-permit" class="usa-button-primary-alt usa-button usa-button-big display-inline" routerLink="/special-use/help-me-pick/1">Help me find a permit</a>
+    <div class="big-col">
+      <h2 class="left-align">I’m not sure which permit I need...</h2>
+      <p class="left-align">If you’re not sure about what kind of permit you need, click on the button below to answer a few questions. We will guide you to the permit that best meets your needs.</p>
+    </div>
+    <div class="small-col">
+      <a id="help-find-permit" class="usa-button-primary-alt usa-button usa-button display-inline" routerLink="/special-use/help-me-pick/1">Help me find a permit</a>
+    </div>
+  </div>
+
+  <div class="help-pick-flex" id="help-pick-background">
+    <div class="small-col small-col-left">
+      <span class="hero-icon">
+        <i class="fas fa-tree usa-ico"></i>
+      </span>
+    </div>
+    <div class="big-col">
+      <h2 class="left-align">Looking for Christmas trees?</h2>
+      <p class="left-align">Please click on the following link to be redirected to the new online sales of Christmas Tree permits for the USFS at <a href="https://www.recreation.gov/">recreation.gov</a></p>
+    </div>
+    <div class="small-col"></div>
   </div>
 
   <div class="usa-grid find-forest">

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
@@ -1,88 +1,14 @@
-<section id="forest-finder-intro" class="usa-hero">
+<section class="usa-section">
   <div class="usa-grid">
-    <div class="usa-hero-callout usa-section-dark">
-      <h1 id="skip-nav-target" tabindex="-1">Buy a Christmas tree permit with Open Forest</h1>
-      <p>The U.S. Forest Service invites you to purchase permits to cut down Christmas trees in some national forests, following certain rules and guidelines.</p>
-      <div id="forest-finder-form">
-        <form name='forestPickerForm' class="usa-forms" (submit)="goToForest(selectedForest)" autocomplete="off">
-          <label for="forest-finder-select">Choose your forest <span>(required)</span></label>
-          <select
-           required
-           #forestFinder
-           role="listbox"
-           (click)="showForestSelectError = false"
-           [(ngModel)]="selectedForest"
-           id="forest-finder-select"
-           name="forestFinderSelect"
-          >
-            <option value="" disabled selected>Select a forest</option>
-            <option role='option' *ngFor="let forest of forests" [ngValue]="forest">{{ forest.description }}</option>
-          </select>
-          <div id='forest-finder-error' aria-live="assertive" [ngClass]="{ 'hidden': !showForestSelectError }">
-            <span tabindex="0" *ngIf="showForestSelectError">You are required to choose a forest.</span>
-          </div>
-          <input id='forest-finder-submit' class='usa-button usa-button-inverse' type='submit' value='Get started now' />
-        </form>
-      </div>
-    </div>
-  </div>
-</section>
-<section id="what-to-expect" class="usa-section">
-  <div class="usa-grid">
-    <h2>What to expect</h2>
-    <div class="usa-width-one-third">
-      <div id="what-to-expect-image-container" class="vertical-center">
-        <a class="cursor-text" href='#' (click)="scrollToForestFinder($event)">
-          <img alt="" role="img" width="150" src="/assets/img/site-wide/forests-icon.svg" class="padding-right-1">
-        </a>
-        <img alt="choose your forest then explore" role="img" width="150" src="/assets/img/site-wide/arrow-next-step.svg" class="padding-right-1 next-arrow">
-      </div>
-      <h3>Choose your forest</h3>
-      <p>
-        Some national forests currently allow you to buy a Christmas tree permit online with Open Forest. Each forest has
-        its own season dates and rules.
-      </p>
-    </div>
-    <div class="usa-width-one-third">
-      <div class="vertical-center transparent">
-        <a class="cursor-text" href='#' (click)="scrollToForestFinder($event)">
-          <img alt="" role="img" width="150" src="/assets/img/site-wide/cutting-icon.svg" class="padding-right-1">
-        </a>
-        <img alt="explore then buy your permit" role="img" width="150" src="/assets/img/site-wide/arrow-next-step.svg" class="padding-right-1 next-arrow">
-      </div>
-      <h3>Get the details</h3>
-      <p>Whether it's your first time, or a long-standing family tradition, learn more about Christmas tree cutting on the
-        national forest you select above.
-      </p>
-    </div>
-    <div class="usa-width-one-third">
-      <div class="vertical-center transparent">
-        <a class="cursor-text" href='#' (click)="scrollToForestFinder($event)">
-          <img alt="" role="img" width="150" src="/assets/img/site-wide/permit-icon.svg" class="padding-right-1">
-        </a>
-      </div>
-      <h3>Buy a permit</h3>
-      <p>Help us ensure national forest resources into the future by carefully reading and following the rules and guidelines for a Christmas tree permit.
-      </p>
-    </div>
-  </div>
-</section>
-<section id="every-kid-in-a-park" class="usa-section usa-section-tan-dark">
-  <div class="usa-grid">
-    <div class="usa-width-one-whole">
-      <div>
-        <img class="every-kid-img" alt="Every kid outdoors" role="img" src="/assets/img/site-wide/eko.png">
-        Fourth graders may be eligible to receive a free Christmas tree permit. Please visit the <a href="https://everykidoutdoors.gov/">Every Kid Outdoors</a> 
-        website or contact your <a href="https://www.fs.fed.us/">local forest service office</a> for details.
-      </div>
-    </div>
-  </div>
-</section>
-<section id="multi-faceted-agency" class="multi-faceted-agency usa-section">
-  <div class="usa-grid">
-    <div class="usa-width-one-whole vertical-center">
-      <div>We are a <a href="https://www.fs.fed.us/about-agency">multi-faceted agency</a> that protects 154 national forests and 20 grasslands in 43 states and Puerto Rico. Our mission is to sustain the health, diversity, and productivity of the nation's forests and grasslands to meet the needs of present and future generations.</div>
-      <img alt="US Forest Service" class="fs-logo padding-left-1" role="img" src="/assets/img/site-wide/usfslogo.svg">
-    </div>
+    <h1>Christmas Trees has moved</h1>
+    <p>Please click on the following link to be redirected to the new online sales of Christmas Tree permits for the USFS at <a href="https://www.recreation.gov/">recreation.gov</a></p>
+    <h2>What can you do?</h2>
+    <ul>
+      <li>Return to the <a href="/special-use">special use permits home page</a></li>
+      <li>Return to the <a href="/">Firewood information page</a></li>
+      <li>Visit a specific <a href="https://www.fs.usda.gov/">National Forest web site</a></li>
+    </ul>
+    <p>If you are experiencing technical issues please <a href="mailto:SM.FS.OpnFrstCsSup@usda.gov">contact the webmaster</a> for help.</p>
+    <p>Thank you for visiting us!</p>
   </div>
 </section>

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.spec.ts
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.spec.ts
@@ -1,69 +1,29 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ForestFinderComponent } from './forest-finder.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ChristmasTreesInfoService } from '../../_services/christmas-trees-info.service';
-import { RemovePuncPipe } from './remove-punc.pipe';
-import { Observable } from 'rxjs/Observable';
-import { ActivatedRoute, Router } from '@angular/router';
-import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { SpacesToDashesPipe } from '../../../_pipes/spaces-to-dashes.pipe';
-import { UtilService } from '../../../_services/util.service';
 import { HttpClientModule } from '@angular/common/http';
 
 describe('ForestFinderComponent', () => {
   let component: ForestFinderComponent;
   let fixture: ComponentFixture<ForestFinderComponent>;
-  let router: Router;
-  let location: Location;
 
-  const mockActivatedRoute = {
-    params: Observable.of({ id: 1 }),
-    data: Observable.of({
-      forests: [
-        {
-          id: 1,
-          forestName: 'Arapaho and Roosevelt',
-          description: 'Arapaho & Roosevelt | Colorado | Fort Collins, CO',
-          forestAbbr: 'arp'
-        },
-        { id: 2, forestName: 'Flathead', description: 'Flathead | Montana | Kalispell, MT', forestAbbr: 'flathead' },
-        { id: 3, forestName: 'Mt. Hood', description: 'Mt. Hood | Oregon | Portland, OR', forestAbbr: 'mthood' },
-        {
-          id: 4,
-          forestName: 'Shoshone',
-          description: 'Shoshone | Montana, Wyoming | Cody, WY, Jackson, WY',
-          forestAbbr: 'shoshone'
-        }
-      ]
-    })
-  };
 
   beforeEach(
     async(() => {
       TestBed.configureTestingModule({
-        declarations: [ForestFinderComponent, RemovePuncPipe, SpacesToDashesPipe],
+        declarations: [ForestFinderComponent],
         schemas: [NO_ERRORS_SCHEMA],
-        providers: [UtilService, { provide: ChristmasTreesInfoService, useClass: ChristmasTreesInfoService }],
+        providers: [],
         imports: [
           HttpClientModule,
           HttpClientTestingModule,
-          RouterTestingModule.withRoutes([
-            {
-              path: 'christmas-trees/forests/:id',
-              component: ForestFinderComponent
-            }
-          ])
         ]
       }).compileComponents();
     })
   );
 
   beforeEach(() => {
-    TestBed.overrideProvider(ActivatedRoute, { useValue: mockActivatedRoute });
-    router = TestBed.get(Router);
-    location = TestBed.get(Location);
     fixture = TestBed.createComponent(ForestFinderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -73,12 +33,8 @@ describe('ForestFinderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it(
-    'should redirect to forest page on click',
-    fakeAsync(() => {
-      component.goToForest({ forestAbbr: 'arp' });
-      tick();
-      expect(location.path()).toBe('/christmas-trees/forests/arp');
-    })
-  );
+  it('should show trees has moved', () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('h1').textContent).toContain('Christmas Trees has moved')
+  })
 });

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.spec.ts
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.spec.ts
@@ -35,6 +35,6 @@ describe('ForestFinderComponent', () => {
 
   it('should show trees has moved', () => {
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Christmas Trees has moved')
-  })
+    expect(compiled.querySelector('h1').textContent).toContain('Christmas Trees has moved');
+  });
 });

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.ts
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.ts
@@ -1,78 +1,22 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
-import { RemovePuncPipe } from './remove-punc.pipe';
+import { Component, OnInit } from '@angular/core';
 
 import { Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-forest-finder',
   templateUrl: './forest-finder.component.html',
-  providers: [RemovePuncPipe]
 })
 export class ForestFinderComponent implements OnInit {
-  @ViewChild('forestFinder') form: ElementRef;
-
-  forests = [];
-  selectedForest = null;
-  itemsPerRow = 2;
-  showForestSelectError = false;
 
   constructor(
-    private route: ActivatedRoute,
-    private router: Router,
     private meta: Meta
   ) {
     this.meta.addTag({
-      name: 'description', content: 'Use Open Forest to purchase\
+      name: 'description', content: 'Use recreation.gov to purchase\
  a Christmas tree permit with the United States Forest Service.'
     });
   }
 
-  /**
-   * Set forest from route resolver
-   */
   ngOnInit() {
-    this.route.data.subscribe(data => {
-      this.forests = data.forests;
-
-      // sort forests alphabetically
-      this.forests.sort(function(a, b) {
-        const forestA = a.description;
-        const forestB = b.description;
-
-        if (forestA < forestB) {
-          return -1;
-        }
-        if (forestA > forestB) {
-          return 1;
-        }
-        return 0;
-      });
-    });
-  }
-
-  /**
-   * Set focus to form
-   */
-  scrollToForestFinder(event) {
-    if (event) {
-      event.preventDefault();
-    }
-
-    this.form.nativeElement.focus();
-
-  }
-
-  /**
-   * Redirect to forest guidelines page
-   */
-  goToForest(forest) {
-    if (forest) {
-      this.showForestSelectError = false;
-      const navTo = '/christmas-trees/forests/' + forest.forestAbbr;
-      this.router.navigate([navTo]);
-    } else {
-      this.showForestSelectError = true;
-    }
   }
 }

--- a/frontend/src/sass/pages/main-landing.scss
+++ b/frontend/src/sass/pages/main-landing.scss
@@ -119,7 +119,6 @@
 #help-pick-background{
   background-color: $fs-tan-dark;
   padding: 20px;
-  margin-top: 40px;
   color: $dark-blue-grey;
   .small-col-left{
     display: none;
@@ -185,7 +184,7 @@
   }
 
   #help-pick-background{
-    padding: 20px 100px;
+    padding: 50px 150px;
     .small-col-left{
       display: unset;
     }


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1355 

Please note if fully resolves the issue per the acceptance criteria: Y

*Addition of the re-route for christmas trees to rec.gov. This PR also includes the home page help-me-pick re-design implemented 4 months ago to match the new christmas tree banner on the home page. These are made to match mockups in issue #1355 *

## Impacted Areas of the Site
- /
- /christmas-trees/forests

## Optional Screenshots
<img width="1647" alt="Screen Shot 2020-09-09 at 1 58 35 PM" src="https://user-images.githubusercontent.com/18233188/92635964-a1b87480-f2a4-11ea-8098-41e1bbc44b75.png">
<img width="1616" alt="Screen Shot 2020-09-09 at 1 58 55 PM" src="https://user-images.githubusercontent.com/18233188/92635969-a4b36500-f2a4-11ea-8e83-4b3d7264b1c5.png">


## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [x] This code has been reviewed by someone other than the original author
