### PR TITLE
Fix session cookie options

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -59,12 +59,10 @@ app.use(
     name: 'session',
     keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
     maxAge: 3600000, // 1 hour
-    cookie: {
-      secure: true,
-      httpOnly: true,
-      domain,
-      sameSite: 'none'
-    }
+    secure: true,
+    httpOnly: true,
+    domain,
+    sameSite: 'none'
   })
 );
 


### PR DESCRIPTION
The cookie options passed into `cookie-session` should not be in a nested `cookie` object. The `secure` and `httpOnly` attributes were getting set correctly because their default values just happen to be correct. I can't be certain this is the fix, but it will definitely prevent the `samesite` attribute from being set.

I also wasn't sure what branch to direct this PR to, so my bad if I picked the wrong thing. 😬 