### PR TITLE
Cookie options - another attempt

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1412,13 +1412,13 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-session": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.3.2.tgz",
-      "integrity": "sha1-Rp26djCMAQtSnpp8+dh7ZJvgGQs=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.4.0.tgz",
+      "integrity": "sha512-0hhwD+BUIwMXQraiZP/J7VP2YFzqo6g4WqZlWHtEHQ22t0MeZZrNBSCxC1zcaLAs8ApT3BzAKizx9gW/AP9vNA==",
       "requires": {
-        "cookies": "0.7.1",
+        "cookies": "0.8.0",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1"
+        "on-headers": "~1.0.2"
       },
       "dependencies": {
         "debug": {
@@ -1443,12 +1443,27 @@
       "dev": true
     },
     "cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
       "requires": {
-        "depd": "~1.1.1",
-        "keygrip": "~1.0.2"
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "keygrip": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+          "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+          "requires": {
+            "tsscmp": "1.0.6"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -5995,6 +6010,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7177,7 +7193,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -8686,9 +8703,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -11789,6 +11806,11 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "body-parser": "1.18.2",
     "body-parser-xml": "^1.1.0",
     "braces": "^3.0.0",
-    "cookie-session": "1.3.2",
+    "cookie-session": "^1.4.0",
     "cors": "^2.8.5",
     "crypto-random-string": "^1.0.0",
     "express": "4.16.0",

--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -59,11 +59,14 @@ app.use(
     name: 'session',
     keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
     maxAge: 3600000, // 1 hour
-    cookie: {
-      secure: true,
-      httpOnly: true,
-      domain
-    }
+    httpOnly: true,
+    sameSite: 'none',
+    // In testing, we use superagent, which wraps the express app, so there's
+    // no actual HTTP calls and therefore no hostname. The test instance also
+    // isn't configured for SSL, so the cookie library will refuse to set a
+    // secure cookie. Thus, modify these two cookie properties accordingly.
+    secure: process.env.NODE_ENV !== 'test',
+    domain: process.env.NODE_ENV === 'test' ? '' : domain
   })
 );
 

--- a/server/test/data/auth-helper.es6
+++ b/server/test/data/auth-helper.es6
@@ -1,9 +1,17 @@
+const assert = require('assert');
+
 module.exports = {
   loginAdmin(agent) {
     return async () => {
       await agent
         .post('/auth/admin/callback')
-        .send({ email: 'test@test.com', password: 'password' });
+        .send({ email: 'test@test.com', password: 'password' })
+        .then((res) => {
+          // Make sure session cookies are always httponly and samesite=none
+          assert(/^session=.* httponly(;|$)/.test(res.headers['set-cookie']));
+          assert(/^session=.* samesite=none(;|$)/.test(res.headers['set-cookie']));
+          return res;
+        });
     };
   },
 
@@ -11,7 +19,13 @@ module.exports = {
     return async () => {
       await agent
         .post('/auth/public/callback')
-        .send({ email: 'test@test.com', password: 'password' });
+        .send({ email: 'test@test.com', password: 'password' })
+        .then((res) => {
+          // Make sure session cookies are always httponly and samesite=none
+          assert(/^session=.* httponly(;|$)/.test(res.headers['set-cookie']));
+          assert(/^session=.* samesite=none(;| )/.test(res.headers['set-cookie']));
+          return res;
+        });
     };
   }
 };


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1418

- Sets the cookie options to enforce domain, httponly, secure, and samesite
   - domain and secure are configured differently in test
- Adds tests to verify that httponly and samesite are always set on authentication calls

## Impacted Areas of the Site
- Login

## This pull request changes...
- [ ] makes admin login in work, hopefully

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- ~Server actions captured by logs (manual)~
- ~Documentation / readme.md updated (manual)~
- ~API docs updated if need (manual)~
- ~JSDocs updated (manual)~
- [ ] This code has been reviewed by someone other than the original author
