### PR TITLE
Re-Add-state_fips-and-Districts

### DIFF
--- a/server/src/controllers/forests/forests.es6
+++ b/server/src/controllers/forests/forests.es6
@@ -18,7 +18,8 @@ fsForests.getForests = (req, res) => {
   forestsDb.fsForests
     .findAll({
       attributes: ['id', 'forestName', 'forestNameShort', 'forestUrl', 'description', 'forestAbbr', 'startDate', 'endDate',
-        'contact', 'mapLinks', 'woodCost', 'state', 'stateFips', 'region', 'permitType', 'minCords', 'maxCords', 'districts'],
+        'contact', 'mapLinks', 'woodCost', 'state', 'stateFips', 'region', 'permitType', 'minCords', 'maxCords',
+        'districts'],
 
       order: [['id', 'ASC']]
     })


### PR DESCRIPTION
﻿## Summary
This PR re-inserts certain data. Namely, the state_fips column and attribute. As well as the 'district' column. These pieces of data were recently removed by mistake which subsequently kept dev from deploying.

## Impacted Areas of the Site
- server/dba/seeders/forests.js
- server/src/controllers/forests/forests.es6

## This pull request is ready to merge when...
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
