### PR TITLE
209-MinCord_MaxCord_Language_Update

### DIFF
--- a/frontend/src/app/application-forms/validators/error-message.component.ts
+++ b/frontend/src/app/application-forms/validators/error-message.component.ts
@@ -74,6 +74,10 @@ export class ErrorMessageComponent {
     } and less than or equal to ${errors.lessThanOrEqualFail.number}. `;
   }
 
+  minMaxCordsFail(errors) {
+    return `${this.name} must be between ${errors.minMaxCordsFail.minNumber} and ${errors.minMaxCordsFail.number} cords.`;
+  }
+
   min(errors) {
     return `${this.name} must have a value greater than or equal to ${errors.min.min}. `;
   }

--- a/frontend/src/app/application-forms/validators/number-of-cords-validation.ts
+++ b/frontend/src/app/application-forms/validators/number-of-cords-validation.ts
@@ -7,10 +7,10 @@ export function numberOfCordsValidator(num, minNum = -99999): ValidatorFn {
       const numberRegex = /^(\d+)$/;
       const valid = numberRegex.test(val);
       if (val < minNum) {
-        return { lessThanOrEqualFail: { number: num, minNumber: minNum } };
+        return { minMaxCordsFail: { number: num, minNumber: minNum } };
       }
       if (val > num) {
-        return { lessThanOrEqualFail: { number: num, minNumber: minNum } };
+        return { minMaxCordsFail: { number: num, minNumber: minNum } };
       }
       if (!valid) {
         return { numberRequirement: true };

--- a/frontend/src/app/firewood/forests/buy-firewood-permit/buy-firewood-permit.component.html
+++ b/frontend/src/app/firewood/forests/buy-firewood-permit/buy-firewood-permit.component.html
@@ -148,7 +148,7 @@
       <form [formGroup]="applicationForm" class="usa-form-large" novalidate (ngSubmit)="showRulesForm()">
           <fieldset>
             <legend>Permit details</legend>
-            <app-numer-of-cords [applicantInfo]="applicationForm" (onkeyup)="quantityChange($event)" hintText="Each cord is ${{forest.woodCost}}. Minimum of {{forest.minCords}} cords."></app-numer-of-cords>
+            <app-numer-of-cords [applicantInfo]="applicationForm" (onkeyup)="quantityChange($event)" hintText="Cost: ${{forest.woodCost}}/cord. You can buy {{forest.minCords}} - {{forest.maxCords}} cords."></app-numer-of-cords>
             <label class="margin-top-2">Total cost for firewood permit: ${{totalCost}} </label>
 
             <legend class="firewood-permit-holder-legend">Permit holder information</legend>


### PR DESCRIPTION
﻿## Summary
Addresses Issue # 209
https://app.zenhub.com/workspaces/open-forest-58f8bbe105a35fad2d275a0c/issues/usdaforestservice/usfs-timber-permitting/209

This PR addresses language changes requested in the 209 card. A validator, component .ts file, and a component .html file were all updated to ensure that users are notified of the full range of cords they are allowed to purchase from the minimum necessary input to the max. Additionally, an error message is thrown when the user violates this range. All pertinent language was updated to make this more clear.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
