### PR TITLE
Cookie production fix

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -58,12 +58,15 @@ const domain = vcapConstants.BASE_URL.replace(/https?:\/\//i, '');
 app.use(session({
   name: 'session',
   keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
-  cookie: {
-    sameSite: 'none',
-    maxAge: 3600000,
-    secure: true,
-    domain
-  }
+  maxAge: 3600000, // 1 hour
+  httpOnly: true,
+  sameSite: 'none',
+  // In testing, we use superagent, which wraps the express app, so there's
+  // no actual HTTP calls and therefore no hostname. The test instance also
+  // isn't configured for SSL, so the cookie library will refuse to set a
+  // secure cookie. Thus, modify these two cookie properties accordingly.
+  secure: process.env.NODE_ENV !== 'test',
+  domain: process.env.NODE_ENV === 'test' ? '' : domain
 }));
 
 // eslint-disable-next-line prefer-arrow-callback

--- a/server/test/data/auth-helper.es6
+++ b/server/test/data/auth-helper.es6
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 module.exports = {
   loginAdmin(agent) {
     return async () => {

--- a/server/test/data/auth-helper.es6
+++ b/server/test/data/auth-helper.es6
@@ -3,7 +3,13 @@ module.exports = {
     return async () => {
       await agent
         .post('/auth/admin/callback')
-        .send({ email: 'test@test.com', password: 'password' });
+        .send({ email: 'test@test.com', password: 'password' })
+        .then((res) => {
+          // Make sure session cookies are always httponly and samesite=none
+          assert(/^session=.* httponly(;|$)/.test(res.headers['set-cookie']));
+          assert(/^session=.* samesite=none(;|$)/.test(res.headers['set-cookie']));
+          return res;
+        });
     };
   },
 
@@ -11,7 +17,13 @@ module.exports = {
     return async () => {
       await agent
         .post('/auth/public/callback')
-        .send({ email: 'test@test.com', password: 'password' });
+        .send({ email: 'test@test.com', password: 'password' })
+        .then((res) => {
+          // Make sure session cookies are always httponly and samesite=none
+          assert(/^session=.* httponly(;|$)/.test(res.headers['set-cookie']));
+          assert(/^session=.* samesite=none(;| )/.test(res.headers['set-cookie']));
+          return res;
+        });
     };
   }
 };


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1418

- Sets the cookie options to enforce domain, httponly, secure, and samesite
- domain and secure are configured differently in test
- Adds tests to verify that httponly and samesite are always set on authentication calls

## Impacted Areas of the Site
- Login

## Optional Screenshots

## This pull request changes...
- [x] makes admin login in work, hopefully

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [x] Server actions captured by logs (manual)
- [x] Documentation / readme.md updated (manual)
- [x] API docs updated if need (manual)
- [x] JSDocs updated (manual)
- [x] This code has been reviewed by someone other than the original author
