### PR TITLE
210_remove_christmas_tree_backlinks/update_recreation.gov_link

### DIFF
--- a/frontend/src/app/error-pages/not-found.component.html
+++ b/frontend/src/app/error-pages/not-found.component.html
@@ -5,7 +5,6 @@
     <h2>What can you do?</h2>
     <ul>
       <li>Return to the <a href="/special-use">special use permits home page</a>.</li>
-      <li>Return to the <a href="/christmas-trees/forests">Christmas tree information page</a>.</li>
       <li>Visit a specific <a href="https://www.fs.fed.us/">National Forest web site</a>.</li>
       <li>Check your bookmark or the URL (web address) for proper spelling and completeness.</li>
     </ul>

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
@@ -1,7 +1,7 @@
 <section class="usa-section">
   <div class="usa-grid">
     <h1>Christmas Trees has moved</h1>
-    <p>Please click on the following link to be redirected to the new online sales of Christmas Tree permits for the USFS at <a href="https://www.recreation.gov/">recreation.gov</a></p>
+    <p>Please click on the following link to be redirected to the new online sales of Christmas Tree permits for the USFS at <a href="https://www.recreation.gov/tree-permits/">recreation.gov</a></p>
     <h2>What can you do?</h2>
     <ul>
       <li>Return to the <a href="/special-use">special use permits home page</a></li>


### PR DESCRIPTION
﻿## Summary
Addresses Issue # 210
https://app.zenhub.com/workspaces/open-forest-58f8bbe105a35fad2d275a0c/issues/usdaforestservice/usfs-timber-permitting/210

This PR addresses changes requested for the 404 page, removing the internal Christmas trees link and updating the external recreation.gov link to include the `/tree-permits` extension.

## This pull request is ready to merge when...
- [x] Feature branch starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
